### PR TITLE
fix(fs): prevent path traversal for files and  hardlinks

### DIFF
--- a/src/fs/unpack.ts
+++ b/src/fs/unpack.ts
@@ -41,141 +41,33 @@ export function unpackTar(
 	directoryPath: string,
 	options: UnpackOptionsFS = {},
 ): Writable {
-	// Convert the reading end of the bridge to a Web ReadableStream.
 	const bridge = new PassThrough();
-	const webReadable = Readable.toWeb(bridge);
 
-	const processingPromise = (async () => {
-		const { validateSymlinks = true } = options;
-		const resolvedDestDir = path.resolve(directoryPath);
-		const createdDirs = new Set<string>();
+	const readable = new ReadableStream({
+		start(controller) {
+			bridge.on("data", (chunk) => controller.enqueue(chunk));
+			bridge.on("end", () => controller.close());
+			bridge.on("error", (err) => controller.error(err));
+		},
 
-		// Ensure destination directory exists upfront
-		await fs.mkdir(resolvedDestDir, { recursive: true });
-		createdDirs.add(resolvedDestDir);
-
-		const entryStream = webReadable
-			.pipeThrough(createTarDecoder())
-			.pipeThrough(createTarOptionsTransformer(options));
-
-		for await (const entry of entryStream) {
-			const header = entry.header;
-			const outPath = path.normalize(path.resolve(directoryPath, header.name));
-
-			// Prevent path traversal attacks that escape the target directory.
-			if (
-				!outPath.startsWith(resolvedDestDir + path.sep) &&
-				outPath !== resolvedDestDir
-			) {
-				throw new Error(
-					`Path traversal attempt detected for entry "${header.name}".`,
-				);
-			}
-
-			const parentDir = path.dirname(outPath);
-
-			// Only create a directory if it hasn't been seen before
-			if (!createdDirs.has(parentDir)) {
-				await fs.mkdir(parentDir, { recursive: true });
-				createdDirs.add(parentDir);
-			}
-
-			switch (header.type) {
-				case "directory": {
-					const mode = options.dmode ?? header.mode;
-					// Check if the directory was already created as a parent of another entry
-					if (createdDirs.has(outPath) && mode) {
-						// If so, just ensure the permissions are correct
-						await fs.chmod(outPath, mode);
-					} else {
-						// Otherwise, create it with the correct permissions
-						await fs.mkdir(outPath, { recursive: true, mode });
-						createdDirs.add(outPath);
-					}
-					break;
-				}
-
-				case "file": {
-					await pipeline(
-						Readable.fromWeb(entry.body),
-						createWriteStream(outPath, { mode: options.fmode ?? header.mode }),
-					);
-
-					break;
-				}
-
-				case "symlink":
-					if (header.linkname) {
-						// Prevent path traversal attacks via symlinks.
-						if (validateSymlinks) {
-							const symlinkDir = path.dirname(outPath);
-							const resolvedTarget = path.normalize(
-								path.resolve(symlinkDir, header.linkname),
-							);
-
-							if (
-								!resolvedTarget.startsWith(resolvedDestDir + path.sep) &&
-								resolvedTarget !== resolvedDestDir
-							) {
-								throw new Error(
-									`Symlink target "${header.linkname}" points outside of the extraction directory.`,
-								);
-							}
-						}
-
-						await fs.symlink(header.linkname, outPath);
-					}
-					break;
-
-				case "link":
-					if (header.linkname) {
-						const resolvedLinkTarget = path.normalize(
-							path.resolve(directoryPath, header.linkname),
-						);
-
-						// Prevent path traversal attacks via hardlinks.
-						if (
-							!resolvedLinkTarget.startsWith(resolvedDestDir + path.sep) &&
-							resolvedLinkTarget !== resolvedDestDir
-						) {
-							throw new Error(
-								`Hardlink target "${header.linkname}" points outside of the extraction directory.`,
-							);
-						}
-
-						await fs.link(resolvedLinkTarget, outPath);
-					}
-
-					break;
-			}
-
-			// Apply timestamps if available
-			if (header.mtime) {
-				try {
-					const utimesFn = header.type === "symlink" ? fs.lutimes : fs.utimes;
-					await utimesFn(outPath, header.mtime, header.mtime);
-				} catch {
-					// Ignore timestamp errors
-				}
-			}
-		}
-	})();
+		cancel(reason) {
+			bridge.destroy(
+				reason instanceof Error ? reason : new Error(String(reason)),
+			);
+		},
+	});
 
 	const writable = new Writable({
 		write(chunk, encoding, callback) {
-			// This respects backpressure from the file system and parser.
 			if (!bridge.write(chunk, encoding)) {
 				bridge.once("drain", callback);
 				return;
 			}
-
 			callback();
 		},
 
 		final(callback) {
 			bridge.end();
-			// Attach the final callback to the processing promise to ensure
-			// all files are written before the stream finishes.
 			processingPromise.then(() => callback()).catch(callback);
 		},
 
@@ -183,6 +75,127 @@ export function unpackTar(
 			bridge.destroy(err as Error | undefined);
 			callback(err);
 		},
+	});
+
+	const processingPromise = (async () => {
+		const resolvedDestDir = path.resolve(directoryPath);
+		const createdDirs = new Set<string>();
+
+		// Ensure destination directory exists upfront
+		await fs.mkdir(resolvedDestDir, { recursive: true });
+		createdDirs.add(resolvedDestDir);
+
+		const entryStream = readable
+			.pipeThrough(createTarDecoder())
+			.pipeThrough(createTarOptionsTransformer(options));
+
+		const reader = entryStream.getReader();
+		try {
+			while (true) {
+				const { done, value: entry } = await reader.read();
+				if (done) break;
+
+				const { header } = entry;
+
+				// Check for absolute paths in the entry name
+				if (path.isAbsolute(header.name)) {
+					throw new Error(
+						`Path traversal attempt detected for entry "${header.name}".`,
+					);
+				}
+
+				const outPath = path.join(resolvedDestDir, header.name);
+
+				if (!outPath.startsWith(resolvedDestDir)) {
+					throw new Error(
+						`Path traversal attempt detected for entry "${header.name}".`,
+					);
+				}
+
+				const parentDir = path.dirname(outPath);
+				// Only create a directory if it hasn't been seen before
+				if (!createdDirs.has(parentDir)) {
+					await fs.mkdir(parentDir, { recursive: true });
+					createdDirs.add(parentDir);
+				}
+
+				switch (header.type) {
+					case "directory": {
+						const mode = options.dmode ?? header.mode;
+						// Check if the directory was already created as a parent of another entry
+						if (createdDirs.has(outPath) && mode) {
+							// If so, just ensure the permissions are correct
+							await fs.chmod(outPath, mode);
+						} else {
+							// Otherwise, create it with the correct permissions
+							await fs.mkdir(outPath, { recursive: true, mode });
+							createdDirs.add(outPath);
+						}
+						break;
+					}
+
+					case "file": {
+						await pipeline(
+							Readable.fromWeb(entry.body),
+							createWriteStream(outPath, {
+								mode: options.fmode ?? header.mode,
+							}),
+						);
+						break;
+					}
+
+					case "symlink": {
+						if (!header.linkname) break;
+
+						if (options.validateSymlinks ?? true) {
+							const symlinkDir = path.dirname(outPath);
+							const resolvedTarget = path.resolve(symlinkDir, header.linkname);
+							if (!resolvedTarget.startsWith(resolvedDestDir)) {
+								throw new Error(
+									`Symlink target "${header.linkname}" points outside the extraction directory.`,
+								);
+							}
+						}
+						await fs.symlink(header.linkname, outPath);
+						break;
+					}
+
+					case "link": {
+						if (!header.linkname) break;
+
+						const resolvedLinkTarget = path.resolve(
+							resolvedDestDir,
+							header.linkname,
+						);
+						if (!resolvedLinkTarget.startsWith(resolvedDestDir)) {
+							throw new Error(
+								`Hardlink target "${header.linkname}" points outside the extraction directory.`,
+							);
+						}
+
+						await fs.link(resolvedLinkTarget, outPath);
+
+						break;
+					}
+				}
+
+				// Apply timestamps if available
+				if (header.mtime) {
+					try {
+						const utimesFn = header.type === "symlink" ? fs.lutimes : fs.utimes;
+						await utimesFn(outPath, header.mtime, header.mtime);
+					} catch {
+						// Ignore timestamp errors
+					}
+				}
+			}
+		} finally {
+			reader.releaseLock();
+		}
+	})();
+
+	processingPromise.catch((err) => {
+		writable.destroy(err);
 	});
 
 	return writable;

--- a/src/fs/unpack.ts
+++ b/src/fs/unpack.ts
@@ -60,7 +60,7 @@ export function unpackTar(
 
 		for await (const entry of entryStream) {
 			const header = entry.header;
-			const outPath = path.resolve(directoryPath, header.name);
+			const outPath = path.normalize(path.resolve(directoryPath, header.name));
 
 			// Prevent path traversal attacks that escape the target directory.
 			if (
@@ -109,7 +109,9 @@ export function unpackTar(
 						// Prevent path traversal attacks via symlinks.
 						if (validateSymlinks) {
 							const symlinkDir = path.dirname(outPath);
-							const resolvedTarget = path.resolve(symlinkDir, header.linkname);
+							const resolvedTarget = path.normalize(
+								path.resolve(symlinkDir, header.linkname),
+							);
 
 							if (
 								!resolvedTarget.startsWith(resolvedDestDir + path.sep) &&
@@ -127,9 +129,8 @@ export function unpackTar(
 
 				case "link":
 					if (header.linkname) {
-						const resolvedLinkTarget = path.resolve(
-							directoryPath,
-							header.linkname,
+						const resolvedLinkTarget = path.normalize(
+							path.resolve(directoryPath, header.linkname),
 						);
 
 						// Prevent path traversal attacks via hardlinks.

--- a/tests/fs/links-traversal.test.ts
+++ b/tests/fs/links-traversal.test.ts
@@ -67,7 +67,7 @@ describe("symlink traversal", () => {
 
 			// This should throw an error
 			await expect(pipeline(maliciousTar, unpackStream)).rejects.toThrow(
-				'Symlink target "../../etc/passwd" points outside of the extraction directory.',
+				'Symlink target "../../etc/passwd" points outside the extraction directory.',
 			);
 		},
 	);
@@ -84,7 +84,7 @@ describe("symlink traversal", () => {
 
 			// This should throw an error
 			await expect(pipeline(maliciousTar, unpackStream)).rejects.toThrow(
-				'Symlink target "/etc/passwd" points outside of the extraction directory.',
+				'Symlink target "/etc/passwd" points outside the extraction directory.',
 			);
 		},
 	);
@@ -191,7 +191,7 @@ describe("symlink traversal", () => {
 
 			// This should throw an error
 			await expect(pipeline(maliciousTar, unpackStream)).rejects.toThrow(
-				"points outside of the extraction directory",
+				"points outside the extraction directory",
 			);
 		},
 	);
@@ -235,7 +235,7 @@ describe("symlink traversal", () => {
 
 			// This should throw an error even for nested symlinks
 			await expect(pipeline(maliciousTar, unpackStream)).rejects.toThrow(
-				"points outside of the extraction directory",
+				"points outside the extraction directory",
 			);
 		},
 	);
@@ -276,7 +276,7 @@ describe("symlink traversal", () => {
 
 			// This should throw an error as the resolved path goes outside
 			await expect(pipeline(maliciousTar, unpackStream)).rejects.toThrow(
-				"points outside of the extraction directory",
+				"points outside the extraction directory",
 			);
 		},
 	);
@@ -294,7 +294,7 @@ describe("symlink traversal", () => {
 
 			// This should throw an error since validation is enabled by default
 			await expect(pipeline(maliciousTar, unpackStream)).rejects.toThrow(
-				'Symlink target "../../etc/passwd" points outside of the extraction directory.',
+				'Symlink target "../../etc/passwd" points outside the extraction directory.',
 			);
 		},
 	);

--- a/tests/fs/path-traversal.test.ts
+++ b/tests/fs/path-traversal.test.ts
@@ -1,0 +1,515 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { unpackTar } from "../../src/fs/index";
+import type { TarEntry } from "../../src/web/index";
+import { packTar } from "../../src/web/index";
+
+describe("path traversal (zip slip) prevention", () => {
+	let tmpDir: string;
+
+	beforeEach(async () => {
+		tmpDir = await fs.mkdtemp(
+			path.join(os.tmpdir(), "modern-tar-path-traversal-test-"),
+		);
+	});
+
+	afterEach(async () => {
+		await fs.rm(tmpDir, { recursive: true, force: true });
+	});
+
+	const createTarWithMaliciousFile = async (
+		fileName: string,
+	): Promise<Readable> => {
+		const entries: TarEntry[] = [
+			{
+				header: {
+					name: "safe-file.txt",
+					size: 14,
+					type: "file",
+					mode: 0o644,
+					mtime: new Date(),
+					uid: 0,
+					gid: 0,
+				},
+				body: "malicious data",
+			},
+			{
+				header: {
+					name: fileName,
+					size: 14,
+					type: "file",
+					mode: 0o644,
+					mtime: new Date(),
+					uid: 0,
+					gid: 0,
+				},
+				body: "malicious data",
+			},
+		];
+
+		const tarBuffer = await packTar(entries);
+		return Readable.from([tarBuffer]);
+	};
+
+	const createTarWithMaliciousDirectory = async (
+		dirName: string,
+	): Promise<Readable> => {
+		const entries: TarEntry[] = [
+			{
+				header: {
+					name: "safe-dir/",
+					size: 0,
+					type: "directory",
+					mode: 0o755,
+					mtime: new Date(),
+					uid: 0,
+					gid: 0,
+				},
+			},
+			{
+				header: {
+					name: dirName,
+					size: 0,
+					type: "directory",
+					mode: 0o755,
+					mtime: new Date(),
+					uid: 0,
+					gid: 0,
+				},
+			},
+		];
+
+		const tarBuffer = await packTar(entries);
+		return Readable.from([tarBuffer]);
+	};
+
+	const createTarWithMaliciousHardlink = async (
+		fileName: string,
+		linkTarget: string,
+	): Promise<Readable> => {
+		const entries: TarEntry[] = [
+			{
+				header: {
+					name: "safe-file.txt",
+					size: 14,
+					type: "file",
+					mode: 0o644,
+					mtime: new Date(),
+					uid: 0,
+					gid: 0,
+				},
+				body: "malicious data",
+			},
+			{
+				header: {
+					name: fileName,
+					size: 0,
+					type: "link",
+					mode: 0o644,
+					mtime: new Date(),
+					uid: 0,
+					gid: 0,
+					linkname: linkTarget,
+				},
+			},
+		];
+
+		const tarBuffer = await packTar(entries);
+		return Readable.from([tarBuffer]);
+	};
+
+	describe("file path traversal", () => {
+		it("prevents files with relative path traversal", async () => {
+			const extractDir = path.join(tmpDir, "extract");
+			await fs.mkdir(extractDir, { recursive: true });
+
+			// Create a malicious tar with file path pointing outside extraction directory
+			const maliciousTar = await createTarWithMaliciousFile(
+				"../../malicious.txt",
+			);
+			const unpackStream = unpackTar(extractDir);
+
+			// This should throw an error
+			await expect(pipeline(maliciousTar, unpackStream)).rejects.toThrow(
+				'Path traversal attempt detected for entry "../../malicious.txt".',
+			);
+		});
+
+		it("prevents files with absolute paths", async () => {
+			const extractDir = path.join(tmpDir, "extract");
+			await fs.mkdir(extractDir, { recursive: true });
+
+			// Create a malicious tar with absolute path
+			const maliciousTar =
+				await createTarWithMaliciousFile("/tmp/malicious.txt");
+			const unpackStream = unpackTar(extractDir);
+
+			// This should throw an error
+			await expect(pipeline(maliciousTar, unpackStream)).rejects.toThrow(
+				'Path traversal attempt detected for entry "/tmp/malicious.txt".',
+			);
+		});
+
+		it("prevents files with complex path traversal", async () => {
+			const extractDir = path.join(tmpDir, "extract");
+			await fs.mkdir(extractDir, { recursive: true });
+
+			// Create a malicious tar with complex traversal
+			const maliciousTar = await createTarWithMaliciousFile(
+				"./safe/../../../malicious.txt",
+			);
+			const unpackStream = unpackTar(extractDir);
+
+			// This should throw an error
+			await expect(pipeline(maliciousTar, unpackStream)).rejects.toThrow(
+				'Path traversal attempt detected for entry "./safe/../../../malicious.txt".',
+			);
+		});
+
+		it("allows safe file paths within extraction directory", async () => {
+			const extractDir = path.join(tmpDir, "extract");
+			await fs.mkdir(extractDir, { recursive: true });
+
+			// Create a safe tar with file in subdirectory
+			const safeTar = await createTarWithMaliciousFile("subdir/safe.txt");
+			const unpackStream = unpackTar(extractDir);
+
+			// This should succeed
+			await expect(pipeline(safeTar, unpackStream)).resolves.toBeUndefined();
+
+			// Verify the file was created in the correct location
+			const filePath = path.join(extractDir, "subdir", "safe.txt");
+			const fileContent = await fs.readFile(filePath, "utf8");
+			expect(fileContent).toBe("malicious data");
+		});
+
+		it("allows files with safe relative paths", async () => {
+			const extractDir = path.join(tmpDir, "extract");
+			await fs.mkdir(extractDir, { recursive: true });
+
+			// Create a tar with safe relative path that stays within bounds
+			const safeTar = await createTarWithMaliciousFile("./subdir/../safe.txt");
+			const unpackStream = unpackTar(extractDir);
+
+			// This should succeed as the resolved path is within the extraction directory
+			await expect(pipeline(safeTar, unpackStream)).resolves.toBeUndefined();
+
+			const filePath = path.join(extractDir, "safe.txt");
+			const fileContent = await fs.readFile(filePath, "utf8");
+			expect(fileContent).toBe("malicious data");
+		});
+	});
+
+	describe("directory path traversal", () => {
+		it("prevents directories with relative path traversal", async () => {
+			const extractDir = path.join(tmpDir, "extract");
+			await fs.mkdir(extractDir, { recursive: true });
+
+			// Create a malicious tar with directory path pointing outside extraction directory
+			const maliciousTar =
+				await createTarWithMaliciousDirectory("../../malicious/");
+			const unpackStream = unpackTar(extractDir);
+
+			// This should throw an error
+			await expect(pipeline(maliciousTar, unpackStream)).rejects.toThrow(
+				'Path traversal attempt detected for entry "../../malicious/".',
+			);
+		});
+
+		it("prevents directories with absolute paths", async () => {
+			const extractDir = path.join(tmpDir, "extract");
+			await fs.mkdir(extractDir, { recursive: true });
+
+			// Create a malicious tar with absolute directory path
+			const maliciousTar =
+				await createTarWithMaliciousDirectory("/tmp/malicious/");
+			const unpackStream = unpackTar(extractDir);
+
+			// This should throw an error
+			await expect(pipeline(maliciousTar, unpackStream)).rejects.toThrow(
+				'Path traversal attempt detected for entry "/tmp/malicious/".',
+			);
+		});
+
+		it("allows safe directory paths", async () => {
+			const extractDir = path.join(tmpDir, "extract");
+			await fs.mkdir(extractDir, { recursive: true });
+
+			// Create a safe tar with directory
+			const safeTar = await createTarWithMaliciousDirectory("subdir/nested/");
+			const unpackStream = unpackTar(extractDir);
+
+			// This should succeed
+			await expect(pipeline(safeTar, unpackStream)).resolves.toBeUndefined();
+
+			// Verify the directory was created
+			const dirPath = path.join(extractDir, "subdir", "nested");
+			const dirStat = await fs.stat(dirPath);
+			expect(dirStat.isDirectory()).toBe(true);
+		});
+	});
+
+	describe("hardlink path traversal", () => {
+		it("prevents hardlinks with relative path traversal in target", async () => {
+			const extractDir = path.join(tmpDir, "extract");
+			await fs.mkdir(extractDir, { recursive: true });
+
+			// Create a malicious tar with hardlink target pointing outside extraction directory
+			const maliciousTar = await createTarWithMaliciousHardlink(
+				"link.txt",
+				"../../target.txt",
+			);
+			const unpackStream = unpackTar(extractDir);
+
+			// This should throw an error
+			await expect(pipeline(maliciousTar, unpackStream)).rejects.toThrow(
+				'Hardlink target "../../target.txt" points outside of the extraction directory.',
+			);
+		});
+
+		it("prevents hardlinks with absolute paths in target", async () => {
+			const extractDir = path.join(tmpDir, "extract");
+			await fs.mkdir(extractDir, { recursive: true });
+
+			// Create a malicious tar with absolute hardlink target
+			const maliciousTar = await createTarWithMaliciousHardlink(
+				"link.txt",
+				"/tmp/target.txt",
+			);
+			const unpackStream = unpackTar(extractDir);
+
+			// This should throw an error
+			await expect(pipeline(maliciousTar, unpackStream)).rejects.toThrow(
+				'Hardlink target "/tmp/target.txt" points outside of the extraction directory.',
+			);
+		});
+
+		it("allows safe hardlinks within extraction directory", async () => {
+			const extractDir = path.join(tmpDir, "extract");
+			await fs.mkdir(extractDir, { recursive: true });
+
+			// Create a safe tar with hardlink to existing file
+			const safeTar = await createTarWithMaliciousHardlink(
+				"link.txt",
+				"safe-file.txt",
+			);
+			const unpackStream = unpackTar(extractDir);
+
+			// This should succeed
+			await expect(pipeline(safeTar, unpackStream)).resolves.toBeUndefined();
+
+			// Verify both files exist and are hardlinked
+			const originalPath = path.join(extractDir, "safe-file.txt");
+			const linkPath = path.join(extractDir, "link.txt");
+
+			const originalStat = await fs.stat(originalPath);
+			const linkStat = await fs.stat(linkPath);
+
+			// They should have the same inode (hardlinked)
+			expect(originalStat.ino).toBe(linkStat.ino);
+			expect(linkStat.nlink).toBe(2); // Two links to the same file
+		});
+	});
+
+	describe("mixed traversal attempts", () => {
+		it("prevents multiple types of traversal in single archive", async () => {
+			const extractDir = path.join(tmpDir, "extract");
+			await fs.mkdir(extractDir, { recursive: true });
+
+			// Create an archive with multiple traversal attempts
+			const entries: TarEntry[] = [
+				{
+					header: {
+						name: "safe-file.txt",
+						size: 4,
+						type: "file",
+						mode: 0o644,
+						mtime: new Date(),
+						uid: 0,
+						gid: 0,
+					},
+					body: "safe",
+				},
+				{
+					header: {
+						name: "../../malicious-file.txt",
+						size: 14,
+						type: "file",
+						mode: 0o644,
+						mtime: new Date(),
+						uid: 0,
+						gid: 0,
+					},
+					body: "malicious data",
+				},
+				{
+					header: {
+						name: "../../malicious-dir/",
+						size: 0,
+						type: "directory",
+						mode: 0o755,
+						mtime: new Date(),
+						uid: 0,
+						gid: 0,
+					},
+				},
+			];
+
+			const tarBuffer = await packTar(entries);
+			const maliciousTar = Readable.from([tarBuffer]);
+			const unpackStream = unpackTar(extractDir);
+
+			// This should throw an error on the first malicious entry
+			await expect(pipeline(maliciousTar, unpackStream)).rejects.toThrow(
+				"Path traversal attempt detected",
+			);
+		});
+
+		it("processes safe entries before encountering traversal attempt", async () => {
+			const extractDir = path.join(tmpDir, "extract");
+			await fs.mkdir(extractDir, { recursive: true });
+
+			// Create an archive with safe entries first, then malicious
+			const entries: TarEntry[] = [
+				{
+					header: {
+						name: "safe1.txt",
+						size: 14,
+						type: "file",
+						mode: 0o644,
+						mtime: new Date(),
+						uid: 0,
+						gid: 0,
+					},
+					body: "malicious data",
+				},
+				{
+					header: {
+						name: "safe-dir/",
+						size: 0,
+						type: "directory",
+						mode: 0o755,
+						mtime: new Date(),
+						uid: 0,
+						gid: 0,
+					},
+				},
+				{
+					header: {
+						name: "safe-dir/safe2.txt",
+						size: 14,
+						type: "file",
+						mode: 0o644,
+						mtime: new Date(),
+						uid: 0,
+						gid: 0,
+					},
+					body: "malicious data",
+				},
+				{
+					header: {
+						name: "../../../malicious.txt",
+						size: 14,
+						type: "file",
+						mode: 0o644,
+						mtime: new Date(),
+						uid: 0,
+						gid: 0,
+					},
+					body: "malicious data",
+				},
+			];
+
+			const tarBuffer = await packTar(entries);
+			const maliciousTar = Readable.from([tarBuffer]);
+			const unpackStream = unpackTar(extractDir);
+
+			// This should throw an error
+			await expect(pipeline(maliciousTar, unpackStream)).rejects.toThrow(
+				"Path traversal attempt detected",
+			);
+
+			// Verify that safe files were created before the error
+			const safe1Path = path.join(extractDir, "safe1.txt");
+			const safe2Path = path.join(extractDir, "safe-dir", "safe2.txt");
+
+			expect(await fs.readFile(safe1Path, "utf8")).toBe("malicious data");
+			expect(await fs.readFile(safe2Path, "utf8")).toBe("malicious data");
+
+			// Verify malicious file was NOT created
+			const maliciousPath = path.resolve(tmpDir, "malicious.txt");
+			await expect(fs.access(maliciousPath)).rejects.toThrow();
+		});
+	});
+
+	describe("edge cases", () => {
+		it("allows files at extraction directory root", async () => {
+			const extractDir = path.join(tmpDir, "extract");
+			await fs.mkdir(extractDir, { recursive: true });
+
+			// Create a tar with file at root (empty name would be invalid, so use ".")
+			const entries: TarEntry[] = [
+				{
+					header: {
+						name: "root-file.txt",
+						size: 14,
+						type: "file",
+						mode: 0o644,
+						mtime: new Date(),
+						uid: 0,
+						gid: 0,
+					},
+					body: "malicious data",
+				},
+			];
+
+			const tarBuffer = await packTar(entries);
+			const safeTar = Readable.from([tarBuffer]);
+			const unpackStream = unpackTar(extractDir);
+
+			await expect(pipeline(safeTar, unpackStream)).resolves.toBeUndefined();
+
+			const filePath = path.join(extractDir, "root-file.txt");
+			expect(await fs.readFile(filePath, "utf8")).toBe("malicious data");
+		});
+
+		it("handles empty path components correctly", async () => {
+			const extractDir = path.join(tmpDir, "extract");
+			await fs.mkdir(extractDir, { recursive: true });
+
+			// Create a tar with path containing empty components
+			const safeTar = await createTarWithMaliciousFile("./safe//file.txt");
+			const unpackStream = unpackTar(extractDir);
+
+			await expect(pipeline(safeTar, unpackStream)).resolves.toBeUndefined();
+
+			// The file should be created (path.resolve handles empty components)
+			const filePath = path.join(extractDir, "safe", "file.txt");
+			expect(await fs.readFile(filePath, "utf8")).toBe("malicious data");
+		});
+
+		it("prevents traversal with Windows-style paths on Unix", async () => {
+			const extractDir = path.join(tmpDir, "extract");
+			await fs.mkdir(extractDir, { recursive: true });
+
+			// Try Windows-style path traversal (should be treated as filename on Unix)
+			const maliciousTar = await createTarWithMaliciousFile(
+				"..\\..\\malicious.txt",
+			);
+			const unpackStream = unpackTar(extractDir);
+
+			// On Unix, this should be treated as a filename with backslashes
+			await expect(
+				pipeline(maliciousTar, unpackStream),
+			).resolves.toBeUndefined();
+
+			// The file should be created with the literal filename
+			const filePath = path.join(extractDir, "..\\..\\malicious.txt");
+			expect(await fs.readFile(filePath, "utf8")).toBe("malicious data");
+		});
+	});
+});

--- a/tests/fs/path-traversal.test.ts
+++ b/tests/fs/path-traversal.test.ts
@@ -267,7 +267,7 @@ describe("path traversal (zip slip) prevention", () => {
 
 			// This should throw an error
 			await expect(pipeline(maliciousTar, unpackStream)).rejects.toThrow(
-				'Hardlink target "../../target.txt" points outside of the extraction directory.',
+				'Hardlink target "../../target.txt" points outside the extraction directory.',
 			);
 		});
 
@@ -284,7 +284,7 @@ describe("path traversal (zip slip) prevention", () => {
 
 			// This should throw an error
 			await expect(pipeline(maliciousTar, unpackStream)).rejects.toThrow(
-				'Hardlink target "/tmp/target.txt" points outside of the extraction directory.',
+				'Hardlink target "/tmp/target.txt" points outside the extraction directory.',
 			);
 		});
 

--- a/tests/fs/path-traversal.test.ts
+++ b/tests/fs/path-traversal.test.ts
@@ -8,7 +8,7 @@ import { unpackTar } from "../../src/fs/index";
 import type { TarEntry } from "../../src/web/index";
 import { packTar } from "../../src/web/index";
 
-describe("path traversal (zip slip) prevention", () => {
+describe("path traversal prevention", () => {
 	let tmpDir: string;
 
 	beforeEach(async () => {


### PR DESCRIPTION
This adds some fixes to prevent a path traversal attack via hardlinks or normal files. Symlinks are already protected.