### PR TITLE
fix(core): add proper incomplete tar handling

### DIFF
--- a/src/web/stream.ts
+++ b/src/web/stream.ts
@@ -227,8 +227,15 @@ export function createTarDecoder(): TransformStream<
 		},
 
 		flush(controller) {
-			if (currentEntry)
-				controller.error(new Error("Tar archive is truncated."));
+			if (currentEntry) {
+				const error = new Error("Tar archive is truncated.");
+
+				// Error both the current entry and the main stream.
+				currentEntry.controller.error(error);
+				controller.error(error);
+			}
+
+			// Check for non-zero bytes in the leftover buffer.
 			if (buffer.some((b) => b !== 0))
 				controller.error(new Error("Unexpected data at end of archive."));
 		},

--- a/tests/web/extract.test.ts
+++ b/tests/web/extract.test.ts
@@ -5,6 +5,7 @@ import { unpackTar } from "../../src/web/index";
 import { decoder } from "../../src/web/utils";
 import {
 	GNU_TAR,
+	INCOMPLETE_TAR,
 	LONG_NAME_TAR,
 	MULTI_FILE_TAR,
 	ONE_FILE_TAR,
@@ -157,5 +158,14 @@ describe("extract", () => {
 		expect(entry.header.uname).toBe("myuser");
 		expect(entry.header.gname).toBe("mygroup");
 		expect(decoder.decode(entry.data)).toBe("Hello, world!\n");
+	});
+
+	it("throws an error for an incomplete archive", async () => {
+		const buffer = await fs.readFile(INCOMPLETE_TAR);
+
+		// We expect unpackTar to reject because the archive is truncated
+		await expect(unpackTar(buffer)).rejects.toThrow(
+			"Tar archive is truncated.",
+		);
 	});
 });


### PR DESCRIPTION
As ongoing work to get test parity with `tar-stream/tar-fs`, I'll be matching their test cases.

This adds a test for truncated tars and handles it properly.