### PR TITLE
fix(fs): unpack traversal and symlink cache poisoning

### DIFF
--- a/src/fs/unpack.ts
+++ b/src/fs/unpack.ts
@@ -151,6 +151,11 @@ export function unpackTar(
 							);
 						}
 						await fs.symlink(header.linkname, outPath);
+
+						// Invalidate any cached directory entry for this path, which prevents a
+						// cache poisoning attack where a directory is replaced by a symlink.
+						validatedDirs.delete(outPath);
+
 						break;
 					}
 

--- a/tests/fs/security.test.ts
+++ b/tests/fs/security.test.ts
@@ -762,4 +762,336 @@ describe("security", () => {
 			},
 		);
 	});
+
+	describe("CVE-specific attacks", () => {
+		it.skipIf(process.platform === "win32")(
+			"prevents tar-fs symlink traversal vulnerability (CVE-2025-59343)",
+			async () => {
+				const extractDir = path.join(tmpDir, "extract");
+				const evilDir = path.join(tmpDir, "extract-evil");
+				await fs.mkdir(extractDir, { recursive: true });
+				await fs.mkdir(evilDir, { recursive: true });
+
+				const entries: TarEntry[] = [
+					{
+						header: {
+							name: "my-symlink",
+							size: 0,
+							type: "symlink",
+							linkname: "../extract-evil/malicious-file.txt",
+						},
+					},
+				];
+
+				const tarBuffer = await packTar(entries);
+				const maliciousTar = Readable.from([tarBuffer]);
+				const unpackStream = unpackTar(extractDir);
+
+				// With the fix, this should reject the promise
+				await expect(pipeline(maliciousTar, unpackStream)).rejects.toThrow(
+					'Symlink target "../extract-evil/malicious-file.txt" points outside the extraction directory.',
+				);
+
+				// Verify that the malicious file was NOT created
+				const maliciousPath = path.join(evilDir, "malicious-file.txt");
+				await expect(fs.access(maliciousPath)).rejects.toThrow();
+			},
+		);
+
+		it.skipIf(process.platform === "win32")(
+			"prevents hardlink through existing symlink vulnerability (CVE-2025-48387)",
+			async () => {
+				const extractDir = path.join(tmpDir, "extract");
+				const siblingDir = path.join(tmpDir, "sibling");
+				await fs.mkdir(extractDir, { recursive: true });
+				await fs.mkdir(siblingDir, { recursive: true });
+
+				// Create target file outside extraction directory
+				const targetFile = path.join(siblingDir, "victim.txt");
+				await fs.writeFile(targetFile, "original content");
+
+				// Manually create a symlink that points outside (simulating first stage of attack)
+				const symlinkPath = path.join(extractDir, "escape");
+				await fs.symlink("../sibling", symlinkPath);
+
+				// Now create tar with hardlink through the existing symlink
+				const entries: TarEntry[] = [
+					{
+						header: {
+							name: "malicious-hardlink",
+							size: 0,
+							type: "link",
+							linkname: "escape/victim.txt", // This goes through symlink to external file
+						},
+					},
+				];
+
+				const tarBuffer = await packTar(entries);
+				const maliciousTar = Readable.from([tarBuffer]);
+				const unpackStream = unpackTar(extractDir);
+
+				// This should be blocked - hardlink validation should use fs.realpath
+				await expect(pipeline(maliciousTar, unpackStream)).rejects.toThrow(
+					/points outside the extraction directory/,
+				);
+
+				// Verify target file is unchanged
+				const content = await fs.readFile(targetFile, "utf8");
+				expect(content).toBe("original content");
+			},
+		);
+		it.skipIf(process.platform === "win32")(
+			"prevents CVE-2025-48387 multi-stage symlink+hardlink attack",
+			async () => {
+				const extractDir = path.join(tmpDir, "extract");
+				const flagDir = path.join(tmpDir, "flag");
+				await fs.mkdir(extractDir, { recursive: true });
+				await fs.mkdir(flagDir, { recursive: true });
+
+				// Create victim file outside extraction directory
+				const victimFile = path.join(flagDir, "flag");
+				await fs.writeFile(victimFile, "hello world\n");
+
+				// Replicate the exact CVE PoC sequence
+				const entries: TarEntry[] = [
+					// Stage 1: Create root symlink with deep noop path + traversal
+					{
+						header: {
+							name: "root",
+							size: 0,
+							type: "symlink",
+							mode: 0o777,
+							mtime: new Date(),
+							uid: 0,
+							gid: 0,
+							linkname: "noop/".repeat(15) + "../".repeat(15),
+						},
+					},
+					// Stage 2: Create noop symlink pointing to current directory
+					{
+						header: {
+							name: "noop",
+							size: 0,
+							type: "symlink",
+							mode: 0o777,
+							mtime: new Date(),
+							uid: 0,
+							gid: 0,
+							linkname: ".",
+						},
+					},
+					// Stage 3: Create hardlink through the symlink chain to external file
+					{
+						header: {
+							name: "hardflag",
+							size: 0,
+							type: "link",
+							mode: 0o644,
+							mtime: new Date(),
+							uid: 0,
+							gid: 0,
+							linkname: `root${flagDir}/flag`,
+						},
+					},
+					// Stage 4: Overwrite external file via hardlink
+					{
+						header: {
+							name: "hardflag",
+							size: 10,
+							type: "file",
+							mode: 0o644,
+							mtime: new Date(),
+							uid: 0,
+							gid: 0,
+						},
+						body: "overwrite\n",
+					},
+				];
+
+				const tarBuffer = await packTar(entries);
+				const maliciousTar = Readable.from([tarBuffer]);
+				const unpackStream = unpackTar(extractDir);
+
+				// This attack should be blocked
+				await expect(pipeline(maliciousTar, unpackStream)).rejects.toThrow(
+					/points outside the extraction directory/,
+				);
+
+				// Verify victim file is unchanged
+				const content = await fs.readFile(victimFile, "utf8");
+				expect(content).toBe("hello world\n");
+			},
+		);
+
+		it.skipIf(process.platform === "win32")(
+			"prevents symlink chain bypass attack (CVE-2025-48387 variant)",
+			async () => {
+				const extractDir = path.join(tmpDir, "extract");
+				const externalDir = path.join(tmpDir, "external");
+				await fs.mkdir(extractDir, { recursive: true });
+				await fs.mkdir(externalDir, { recursive: true });
+
+				const victimFile = path.join(externalDir, "victim.txt");
+				await fs.writeFile(victimFile, "original");
+
+				const entries: TarEntry[] = [
+					{
+						header: {
+							name: "escape",
+							size: 0,
+							type: "symlink",
+							linkname: "bridge/".repeat(10) + "../".repeat(11),
+						},
+					},
+					{
+						header: {
+							name: "bridge",
+							size: 0,
+							type: "symlink",
+							linkname: ".",
+						},
+					},
+					{
+						header: {
+							name: "attack",
+							size: 0,
+							type: "link",
+							linkname: `escape${externalDir}/victim.txt`,
+						},
+					},
+				];
+
+				const tarBuffer = await packTar(entries);
+				const maliciousTar = Readable.from([tarBuffer]);
+				const unpackStream = unpackTar(extractDir);
+
+				await expect(pipeline(maliciousTar, unpackStream)).rejects.toThrow();
+
+				const content = await fs.readFile(victimFile, "utf8");
+				expect(content).toBe("original");
+			},
+		);
+
+		it.skipIf(process.platform === "win32")(
+			"prevents multi-level symlink+hardlink combinations",
+			async () => {
+				const extractDir = path.join(tmpDir, "extract");
+				const externalFile = path.join(tmpDir, "external.txt");
+				await fs.mkdir(extractDir, { recursive: true });
+				await fs.writeFile(externalFile, "should not be modified");
+
+				const entries: TarEntry[] = [
+					{
+						header: {
+							name: "level1",
+							size: 0,
+							type: "symlink",
+							linkname: "level2",
+						},
+					},
+					{
+						header: {
+							name: "level2",
+							size: 0,
+							type: "symlink",
+							linkname: "level3",
+						},
+					},
+					{
+						header: {
+							name: "level3",
+							size: 0,
+							type: "symlink",
+							linkname: "../../",
+						},
+					},
+					{
+						header: {
+							name: "attack-hardlink",
+							size: 0,
+							type: "link",
+							linkname: `level1${externalFile}`,
+						},
+					},
+					{
+						header: {
+							name: "attack-hardlink",
+							size: 12,
+							type: "file",
+						},
+						body: "compromised!",
+					},
+				];
+
+				const tarBuffer = await packTar(entries);
+				const maliciousTar = Readable.from([tarBuffer]);
+				const unpackStream = unpackTar(extractDir);
+
+				await expect(pipeline(maliciousTar, unpackStream)).rejects.toThrow();
+
+				const content = await fs.readFile(externalFile, "utf8");
+				expect(content).toBe("should not be modified");
+			},
+		);
+
+		it.skipIf(process.platform === "win32")(
+			"prevents overwrite via directory symlink+hardlink",
+			async () => {
+				const extractDir = path.join(tmpDir, "extract");
+				const targetDir = path.join(tmpDir, "target");
+				await fs.mkdir(extractDir, { recursive: true });
+				await fs.mkdir(targetDir, { recursive: true });
+
+				const targetFile = path.join(targetDir, "important.txt");
+				await fs.writeFile(targetFile, "important data");
+
+				const entries: TarEntry[] = [
+					// Create directory that we'll symlink through
+					{
+						header: {
+							name: "gateway/",
+							size: 0,
+							type: "directory",
+						},
+					},
+					// Symlink the directory to point outside
+					{
+						header: {
+							name: "gateway/escape",
+							size: 0,
+							type: "symlink",
+							linkname: "../../target",
+						},
+					},
+					// Create hardlink through the symlinked path
+					{
+						header: {
+							name: "innocent-file",
+							size: 0,
+							type: "link",
+							linkname: "gateway/escape/important.txt",
+						},
+					},
+					// Overwrite via the hardlink
+					{
+						header: {
+							name: "innocent-file",
+							size: 12,
+							type: "file",
+						},
+						body: "hacked data!",
+					},
+				];
+
+				const tarBuffer = await packTar(entries);
+				const maliciousTar = Readable.from([tarBuffer]);
+				const unpackStream = unpackTar(extractDir);
+
+				await expect(pipeline(maliciousTar, unpackStream)).rejects.toThrow();
+
+				const content = await fs.readFile(targetFile, "utf8");
+				expect(content).toBe("important data");
+			},
+		);
+	});
 });


### PR DESCRIPTION
As ongoing efforts to harden this library, I'm going through `tar-fs` and `node-tar`'s CVEs to ensure we don't have the same vulnerabilities. Some are relevant, some are not.

This PR fixes:

- https://github.com/mafintosh/tar-fs/security/advisories/GHSA-8cj5-5rvv-wf4v
- https://github.com/mafintosh/tar-fs/security/advisories/GHSA-vj76-c3g6-qr5v
- https://github.com/isaacs/node-tar/security/advisories/GHSA-r628-mhmh-qjhw

We've removed the created directories cache since it isn't worth the complexity. But we do keep a validation cache like `node-tar` which was susceptible to cache poisoning.