### PR TITLE
fix(fs): add max depth validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,8 @@ const extractStream = unpackTar('./output', {
 
 	// Filesystem-specific options
 	fmode: 0o644, // Override file permissions
-	dmode: 0o755  // Override directory permissions
+	dmode: 0o755, // Override directory permissions
+	maxDepth: 50  // Limit extraction depth for security (default: 1024)
 });
 
 await pipeline(sourceStream, extractStream);
@@ -492,6 +493,14 @@ interface UnpackOptionsFS extends UnpackOptions {
    * @default true
    */
   validateSymlinks?: boolean;
+  /**
+	 * The maximum depth of paths to extract. Prevents Denial of Service (DoS) attacks
+	 * from malicious archives with deeply nested directories.
+	 *
+	 * Set to `Infinity` to disable depth checking (not recommended for untrusted archives).
+	 * @default 1024
+	 */
+  maxDepth?: number;
 }
 ```
 

--- a/src/fs/types.ts
+++ b/src/fs/types.ts
@@ -33,6 +33,14 @@ export interface UnpackOptionsFS extends UnpackOptions {
 	 * @default true
 	 */
 	validateSymlinks?: boolean;
+	/**
+	 * The maximum depth of paths to extract. Prevents Denial of Service (DoS) attacks
+	 * from malicious archives with deeply nested directories.
+	 *
+	 * Set to `Infinity` to disable depth checking (not recommended for untrusted archives).
+	 * @default 1024
+	 */
+	maxDepth?: number;
 }
 
 /** Describes a file on the local filesystem to be added to the archive. */


### PR DESCRIPTION
As ongoing efforts to harden this library, I'm going through tar-fs and node-tar's CVEs to ensure we don't have the same vulnerabilities. Some are relevant, some are not.

This PR fixes:

- https://github.com/isaacs/node-tar/security/advisories/GHSA-f5x3-32g6-xq36

This adds a new `maxDepth` parameter to `unpackTar` to prevent DoS attacks when encountering extremely deeply nested directories.