### PR TITLE
fix(pack): make content type stricter

### DIFF
--- a/src/web/helpers.ts
+++ b/src/web/helpers.ts
@@ -1,7 +1,7 @@
 import { createTarOptionsTransformer } from "./options";
 import { createTarPacker } from "./pack";
-import { createTarDecoder } from "./unpack";
 import type { ParsedTarEntryWithData, TarEntry, UnpackOptions } from "./types";
+import { createTarDecoder } from "./unpack";
 import { encoder } from "./utils";
 
 /**
@@ -61,13 +61,19 @@ export async function packTar(entries: TarEntry[]): Promise<Uint8Array> {
 			} else {
 				// For all other types, normalize to a Uint8Array first.
 				let chunk: Uint8Array;
-				if (typeof body === "string") {
-					chunk = encoder.encode(body);
+
+				if (body === null || body === undefined) {
+					chunk = new Uint8Array(0);
 				} else if (body instanceof Uint8Array) {
 					chunk = body;
-				} else {
-					// Handles the ArrayBuffer case.
+				} else if (body instanceof ArrayBuffer) {
 					chunk = new Uint8Array(body);
+				} else if (typeof body === "string") {
+					chunk = encoder.encode(body);
+				} else {
+					throw new TypeError(
+						`Unsupported content type for entry "${entry.header.name}". Expected string, Uint8Array, ArrayBuffer, Blob, ReadableStream, or undefined.`,
+					);
 				}
 
 				const writer = entryStream.getWriter();

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -5,7 +5,6 @@ export {
 	createTarPacker,
 	type TarPackController,
 } from "./pack";
-export { createTarDecoder } from "./unpack";
 export type {
 	ParsedTarEntry,
 	ParsedTarEntryWithData,
@@ -14,3 +13,4 @@ export type {
 	TarHeader,
 	UnpackOptions,
 } from "./types";
+export { createTarDecoder } from "./unpack";

--- a/src/web/types.ts
+++ b/src/web/types.ts
@@ -49,7 +49,8 @@ export type TarEntryData =
 	| ArrayBuffer
 	| ReadableStream<Uint8Array>
 	| Blob
-	| null;
+	| null
+	| undefined;
 
 /**
  * Represents a complete entry to be packed into a tar archive.

--- a/tests/fs/archive.test.ts
+++ b/tests/fs/archive.test.ts
@@ -455,4 +455,63 @@ describe("packTarSources", () => {
 			}
 		}).rejects.toThrow();
 	});
+
+	it("errors for invalid content types", async () => {
+		// Test invalid content types that could come from JavaScript usage or dynamic data
+		const invalidSources: TarSource[] = [
+			{
+				type: "content",
+				// biome-ignore lint/suspicious/noExplicitAny: Intentionally invalid.
+				content: 123 as any, // number
+				target: "number.txt",
+			},
+		];
+
+		const stream = packTarSources(invalidSources);
+		await expect(
+			new Promise((resolve, reject) => {
+				stream.on("error", reject);
+				stream.on("end", resolve);
+				stream.resume();
+			}),
+		).rejects.toThrow(/Unsupported content type/);
+
+		// Test with boolean
+		const booleanSources: TarSource[] = [
+			{
+				type: "content",
+				// biome-ignore lint/suspicious/noExplicitAny: Intentionally invalid.
+				content: true as any,
+				target: "bool.txt",
+			},
+		];
+
+		const boolStream = packTarSources(booleanSources);
+		await expect(
+			new Promise((resolve, reject) => {
+				boolStream.on("error", reject);
+				boolStream.on("end", resolve);
+				boolStream.resume();
+			}),
+		).rejects.toThrow(/Unsupported content type/);
+
+		// Test with object
+		const objectSources: TarSource[] = [
+			{
+				type: "content",
+				// biome-ignore lint/suspicious/noExplicitAny: Intentionally invalid.
+				content: { invalid: "object" } as any,
+				target: "obj.txt",
+			},
+		];
+
+		const objStream = packTarSources(objectSources);
+		await expect(
+			new Promise((resolve, reject) => {
+				objStream.on("error", reject);
+				objStream.on("end", resolve);
+				objStream.resume();
+			}),
+		).rejects.toThrow(/Unsupported content type/);
+	});
 });

--- a/tests/web/pack.test.ts
+++ b/tests/web/pack.test.ts
@@ -238,4 +238,45 @@ describe("pack", () => {
 		expect(extractedEntries[1].header.type).toBe("directory");
 		expect(extractedEntries[1].header.mode).toBe(0o755);
 	});
+
+	it("errors for invalid body types", async () => {
+		// Test invalid body types that could come from JavaScript usage or dynamic data
+		const invalidEntries: TarEntry[] = [
+			{
+				header: { name: "test.txt", size: 0, type: "file" },
+				// biome-ignore lint/suspicious/noExplicitAny: Intentionally invalid.
+				body: true as any, // boolean
+			},
+		];
+
+		await expect(packTar(invalidEntries)).rejects.toThrow(
+			/Unsupported content type/,
+		);
+
+		// Test with object
+		const objectEntries: TarEntry[] = [
+			{
+				header: { name: "obj.txt", size: 0, type: "file" },
+				// biome-ignore lint/suspicious/noExplicitAny: Intentionally invalid.
+				body: { invalid: "object" } as any,
+			},
+		];
+
+		await expect(packTar(objectEntries)).rejects.toThrow(
+			/Unsupported content type/,
+		);
+
+		// Test with number
+		const numberEntries: TarEntry[] = [
+			{
+				header: { name: "num.txt", size: 0, type: "file" },
+				// biome-ignore lint/suspicious/noExplicitAny: Intentionally invalid.
+				body: 123 as any,
+			},
+		];
+
+		await expect(packTar(numberEntries)).rejects.toThrow(
+			/Unsupported content type/,
+		);
+	});
 });


### PR DESCRIPTION
Although our TypeScript types are strict and don't prevent invalid payloads, this does not prevent normal JavaScript from giving invalid payloads regardless.

This PR throws on any types it does not expect, ensuring we don't process anything we don't expect type wise.