### PR TITLE
perf(web): use proper stream buffer conversion over response hack

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,7 +421,7 @@ interface ParsedTarEntry {
 // Output entry from a buffered unpack function
 interface ParsedTarEntryWithData {
 	header: TarHeader;
-	data: Uint8Array<ArrayBuffer>;
+	data: Uint8Array;
 }
 
 // Platform-neutral configuration for unpacking

--- a/src/fs/archive.ts
+++ b/src/fs/archive.ts
@@ -69,7 +69,7 @@ export function packTarSources(sources: TarSource[]): Readable {
 					if (content instanceof ReadableStream) {
 						const chunks: Buffer[] = [];
 						for await (const chunk of Readable.fromWeb(content)) {
-							chunks.push(chunk as Buffer);
+							chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
 						}
 
 						const buffer = Buffer.concat(chunks);

--- a/src/web/types.ts
+++ b/src/web/types.ts
@@ -77,7 +77,7 @@ export interface ParsedTarEntry {
  */
 export interface ParsedTarEntryWithData {
 	header: TarHeader;
-	data: Uint8Array<ArrayBuffer>;
+	data: Uint8Array;
 }
 
 /**

--- a/tests/web/real-world.test.ts
+++ b/tests/web/real-world.test.ts
@@ -5,6 +5,7 @@ import {
 	type ParsedTarEntryWithData,
 	unpackTar,
 } from "../../src/web";
+import { streamToBuffer } from "../../src/web/utils";
 import { ELECTRON_TGZ, LODASH_TGZ, NEXT_SWC_TGZ, SHARP_TGZ } from "./fixtures";
 
 async function extractTgz(filePath: string): Promise<ParsedTarEntryWithData[]> {
@@ -12,7 +13,7 @@ async function extractTgz(filePath: string): Promise<ParsedTarEntryWithData[]> {
 	const fileStream = ReadableStream.from(fs.createReadStream(filePath));
 
 	const tarStream = fileStream.pipeThrough(createGzipDecoder());
-	const tarBuffer = await new Response(tarStream).arrayBuffer();
+	const tarBuffer = await streamToBuffer(tarStream);
 
 	return unpackTar(tarBuffer);
 }


### PR DESCRIPTION
`await new Response(entry.body).arrayBuffer()` is a one liner to convert a stream to a buffer, but it's still a little hacky since `Response` is very big and can do so many other things. Making a direct helper to consume the stream should cut out some overhead.