### PR TITLE
perf(checksum): skip extra alloc and move to new file

### DIFF
--- a/src/web/checksum.ts
+++ b/src/web/checksum.ts
@@ -1,0 +1,53 @@
+import { USTAR } from "./constants";
+import { readOctal } from "./utils";
+
+// ASCII code for a space character.
+const CHECKSUM_SPACE = 32;
+
+/**
+ * Validates the checksum of a tar header block.
+ */
+export function validateChecksum(block: Uint8Array): boolean {
+	const storedChecksum = readOctal(
+		block,
+		USTAR.checksum.offset,
+		USTAR.checksum.size,
+	);
+
+	// Sum the bytes to get the checksum.
+	let calculatedChecksum = 0;
+	const checksumEnd = USTAR.checksum.offset + USTAR.checksum.size;
+
+	for (let i = 0; i < block.length; i++) {
+		// If the checksum field is included in the sum, it should be treated as if it were filled with ASCII spaces.
+		if (i >= USTAR.checksum.offset && i < checksumEnd) {
+			calculatedChecksum += CHECKSUM_SPACE; // Add space value for checksum field
+		} else {
+			calculatedChecksum += block[i];
+		}
+	}
+
+	return storedChecksum === calculatedChecksum;
+}
+
+/**
+ * Calculates and writes the checksum to a tar header block.
+ */
+export function writeChecksum(block: Uint8Array): void {
+	// Fill the checksum field with spaces.
+	const checksumEnd = USTAR.checksum.offset + USTAR.checksum.size;
+	block.fill(CHECKSUM_SPACE, USTAR.checksum.offset, checksumEnd);
+
+	// Sum the bytes to get the checksum.
+	let checksum = 0;
+	for (const byte of block) {
+		checksum += byte;
+	}
+
+	// Format as a 6-digit octal string, NUL-terminated, and space-padded.
+	const checksumString = `${checksum.toString(8).padStart(6, "0")}\0 `;
+	const checksumBytes = new TextEncoder().encode(checksumString);
+
+	// Write the checksum bytes into the block.
+	block.set(checksumBytes, USTAR.checksum.offset);
+}

--- a/src/web/constants.ts
+++ b/src/web/constants.ts
@@ -31,9 +31,6 @@ export const USTAR = {
 /** USTAR version ("00"). */
 export const USTAR_VERSION = "00";
 
-/** ASCII code for a space character, used as a placeholder in checksum calculation. */
-export const CHECKSUM_SPACE = 32;
-
 /** Type flag constants for file types. */
 export const TYPEFLAG = {
 	file: "0",

--- a/src/web/pack.ts
+++ b/src/web/pack.ts
@@ -1,13 +1,12 @@
+import { writeChecksum } from "./checksum";
 import {
 	BLOCK_SIZE,
-	CHECKSUM_SPACE,
 	DEFAULT_DIR_MODE,
 	DEFAULT_FILE_MODE,
 	TYPEFLAG,
 	USTAR,
 	USTAR_VERSION,
 } from "./constants";
-
 import type { TarHeader } from "./types";
 import { encoder, writeOctal, writeString } from "./utils";
 
@@ -316,22 +315,8 @@ export function createTarHeader(header: TarHeader): Uint8Array {
 	writeString(view, USTAR.gname.offset, USTAR.gname.size, header.gname);
 	writeString(view, USTAR.prefix.offset, USTAR.prefix.size, prefix);
 
-	// Fill the checksum field with spaces before calculating.
-	view.fill(
-		CHECKSUM_SPACE,
-		USTAR.checksum.offset,
-		USTAR.checksum.offset + USTAR.checksum.size,
-	);
-
-	// Sum all bytes in the header.
-	let checksum = 0;
-	for (const byte of view) {
-		checksum += byte;
-	}
-
-	// Write the final checksum value, formatted as a 6-digit octal string followed by a NUL and a space.
-	const checksumString = `${checksum.toString(8).padStart(6, "0")}\0 `;
-	writeString(view, USTAR.checksum.offset, USTAR.checksum.size, checksumString);
+	// Calculate and write the checksum.
+	writeChecksum(view);
 
 	return view;
 }

--- a/tests/web/checksum.test.ts
+++ b/tests/web/checksum.test.ts
@@ -128,4 +128,21 @@ describe("checksum validation", () => {
 			"Invalid tar header checksum",
 		);
 	});
+
+	it("should create headers with correct checksums during packing", async () => {
+		// Pack a simple archive
+		const buffer = await packTar([
+			{
+				header: { name: "checksum-test.txt", size: 11, type: "file" },
+				body: "hello world",
+			},
+		]);
+
+		// If the checksum was calculated correctly during packing,
+		// unpacking should succeed (since unpacker validates checksums)
+		const entries = await unpackTar(buffer);
+		expect(entries).toHaveLength(1);
+		expect(entries[0].header.name).toBe("checksum-test.txt");
+		expect(new TextDecoder().decode(entries[0].data)).toBe("hello world");
+	});
 });


### PR DESCRIPTION
Small performance optimisation where I noticed we didn't really need to make a copy to validate the checksum when we can just work on the buffer directly in a single loop (but with branching but it shouldn't be too bad).

It also moves the checksum logic into a new file since the code is a lot more final now.