### PR TITLE
perf(text): reuse encoder and decoder

### DIFF
--- a/src/web/checksum.ts
+++ b/src/web/checksum.ts
@@ -1,5 +1,5 @@
 import { USTAR } from "./constants";
-import { readOctal } from "./utils";
+import { encoder, readOctal } from "./utils";
 
 // ASCII code for a space character.
 const CHECKSUM_SPACE = 32;
@@ -46,7 +46,7 @@ export function writeChecksum(block: Uint8Array): void {
 
 	// Format as a 6-digit octal string, NUL-terminated, and space-padded.
 	const checksumString = `${checksum.toString(8).padStart(6, "0")}\0 `;
-	const checksumBytes = new TextEncoder().encode(checksumString);
+	const checksumBytes = encoder.encode(checksumString);
 
 	// Write the checksum bytes into the block.
 	block.set(checksumBytes, USTAR.checksum.offset);

--- a/tests/fs/archive.test.ts
+++ b/tests/fs/archive.test.ts
@@ -6,6 +6,7 @@ import { pipeline } from "node:stream/promises";
 import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { packTarSources, type TarSource, unpackTar } from "../../src/fs";
+import { encoder } from "../../src/web/utils";
 
 const isWindows = process.platform === "win32";
 
@@ -166,7 +167,6 @@ describe("packTarSources", () => {
 		const streamContent = "Hello from ReadableStream!";
 		const stream = new ReadableStream({
 			start(controller) {
-				const encoder = new TextEncoder();
 				controller.enqueue(encoder.encode(streamContent));
 				controller.close();
 			},

--- a/tests/web/checksum.test.ts
+++ b/tests/web/checksum.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { createTarPacker, packTar, unpackTar } from "../../src/web";
 import { USTAR } from "../../src/web/constants";
-import { streamToBuffer } from "../../src/web/utils";
+import { decoder, encoder, streamToBuffer } from "../../src/web/utils";
 
 describe("checksum validation", () => {
 	it("should reject tar entries with corrupted checksums", async () => {
@@ -80,7 +80,7 @@ describe("checksum validation", () => {
 			type: "file",
 		});
 		let writer = file1Stream.getWriter();
-		await writer.write(new TextEncoder().encode("valid"));
+		await writer.write(encoder.encode("valid"));
 		await writer.close();
 
 		// Second entry (will be corrupted)
@@ -91,7 +91,7 @@ describe("checksum validation", () => {
 		});
 
 		writer = file2Stream.getWriter();
-		await writer.write(new TextEncoder().encode("corrupt"));
+		await writer.write(encoder.encode("corrupt"));
 		await writer.close();
 
 		controller.finalize();
@@ -143,6 +143,6 @@ describe("checksum validation", () => {
 		const entries = await unpackTar(buffer);
 		expect(entries).toHaveLength(1);
 		expect(entries[0].header.name).toBe("checksum-test.txt");
-		expect(new TextDecoder().decode(entries[0].data)).toBe("hello world");
+		expect(decoder.decode(entries[0].data)).toBe("hello world");
 	});
 });

--- a/tests/web/compression.test.ts
+++ b/tests/web/compression.test.ts
@@ -8,7 +8,7 @@ import {
 	type TarEntry,
 	unpackTar,
 } from "../../src/web/index";
-import { decoder, streamToBuffer } from "../../src/web/utils";
+import { decoder, encoder, streamToBuffer } from "../../src/web/utils";
 
 describe("compression", () => {
 	describe("streaming compression", () => {
@@ -28,7 +28,7 @@ describe("compression", () => {
 				gname: "staff",
 			});
 			const writer = fileStream.getWriter();
-			await writer.write(new TextEncoder().encode("hello"));
+			await writer.write(encoder.encode("hello"));
 			await writer.close();
 			controller.finalize();
 
@@ -76,7 +76,7 @@ describe("compression", () => {
 				mtime: new Date(1387580181000),
 			});
 			const writer1 = file1Stream.getWriter();
-			await writer1.write(new TextEncoder().encode("content1"));
+			await writer1.write(encoder.encode("content1"));
 			await writer1.close();
 
 			const file2Stream = controller.add({
@@ -87,7 +87,7 @@ describe("compression", () => {
 				mtime: new Date(1387580181000),
 			});
 			const writer2 = file2Stream.getWriter();
-			await writer2.write(new TextEncoder().encode("content2"));
+			await writer2.write(encoder.encode("content2"));
 			await writer2.close();
 
 			controller.finalize();
@@ -156,7 +156,7 @@ describe("decompression", () => {
 			);
 
 			for (const entry of entries) {
-				const content = new TextDecoder().decode(entry.data);
+				const content = decoder.decode(entry.data);
 				expect(content).toBe("test content");
 			}
 
@@ -388,7 +388,7 @@ describe("decompression", () => {
 			});
 
 			const writer = fileStream.getWriter();
-			await writer.write(new TextEncoder().encode("partial")); // Only 7 bytes
+			await writer.write(encoder.encode("partial")); // Only 7 bytes
 
 			// This should throw due to size mismatch
 			await expect(writer.close()).rejects.toThrow(/Size mismatch/);
@@ -412,9 +412,9 @@ describe("decompression", () => {
 			const writer = fileStream.getWriter();
 
 			// This should throw when we try to write more than the declared size
-			await writer.write(new TextEncoder().encode("hello")); // 5 bytes - OK
+			await writer.write(encoder.encode("hello")); // 5 bytes - OK
 			await expect(
-				writer.write(new TextEncoder().encode(" world")), // 6 more bytes - should fail
+				writer.write(encoder.encode(" world")), // 6 more bytes - should fail
 			).rejects.toThrow(/larger than its specified size/);
 
 			// Stream should also fail

--- a/tests/web/extract.test.ts
+++ b/tests/web/extract.test.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs/promises";
 import { describe, expect, it } from "vitest";
 import { createTarDecoder, packTar, unpackTar } from "../../src/web";
-import { decoder } from "../../src/web/utils";
+import { decoder, encoder } from "../../src/web/utils";
 import {
 	GNU_TAR,
 	INCOMPLETE_TAR,
@@ -171,7 +171,7 @@ describe("extract", () => {
 	it("extracts a tar with a huge file using PAX headers for size", async () => {
 		const hugeFileSize = "8804630528"; // ~8.2 GB, as a string
 		const smallBody = "this is a placeholder body";
-		const bodyBuffer = new TextEncoder().encode(smallBody);
+		const bodyBuffer = encoder.encode(smallBody);
 
 		const archive = await packTar([
 			{
@@ -191,7 +191,6 @@ describe("extract", () => {
 		// Use streaming API to test just the header parsing without reading full body
 		// @ts-expect-error ReadableStream.from is supported.
 		const sourceStream = ReadableStream.from([archive]);
-		const decoder = new TextDecoder();
 
 		let headerParsed = false;
 		let entry: {


### PR DESCRIPTION
Mostly affects tests, but I noticed I wasn't reusing `TextEncoder` or `TextDecoder` everywhere.