### PR TITLE
feat(unpack): gnu incremental and long filename support

### DIFF
--- a/src/web/constants.ts
+++ b/src/web/constants.ts
@@ -40,6 +40,9 @@ export const TYPEFLAG = {
 	// POSIX.1-2001 extensions
 	"pax-header": "x",
 	"pax-global-header": "g",
+	// GNU extensions
+	"gnu-long-name": "L",
+	"gnu-long-link-name": "K",
 } as const;
 
 /** Reverse mapping from flag characters to type names. */
@@ -48,6 +51,10 @@ export const FLAGTYPE = {
 	"1": "link",
 	"2": "symlink",
 	"5": "directory",
+	// POSIX.1-2001 extensions
 	x: "pax-header",
 	g: "pax-global-header",
+	// GNU extensions
+	L: "gnu-long-name",
+	K: "gnu-long-link-name",
 } as const;

--- a/src/web/types.ts
+++ b/src/web/types.ts
@@ -1,3 +1,5 @@
+import type { TYPEFLAG } from "./constants.js";
+
 /**
  * Header information for a tar entry in USTAR format.
  */
@@ -11,13 +13,7 @@ export interface TarHeader {
 	/** Unix file permissions as an octal number (e.g., 0o644 for rw-r--r--). Defaults to 0o644 for files and 0o755 for directories. */
 	mode?: number;
 	/** Entry type. Defaults to "file" if not specified. */
-	type?:
-		| "file"
-		| "directory"
-		| "symlink"
-		| "link"
-		| "pax-header"
-		| "pax-global-header";
+	type?: keyof typeof TYPEFLAG;
 	/** User ID of the entry owner. */
 	uid?: number;
 	/** Group ID of the entry owner. */

--- a/tests/web/extract.test.ts
+++ b/tests/web/extract.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from "vitest";
 import { createTarDecoder, packTar, unpackTar } from "../../src/web";
 import { decoder, encoder } from "../../src/web/utils";
 import {
-	GNU_TAR,
 	INCOMPLETE_TAR,
 	LONG_NAME_TAR,
 	MULTI_FILE_TAR,
@@ -141,22 +140,6 @@ describe("extract", () => {
 		expect(entries[0].header.name).toHaveLength(100);
 		expect(entries[0].header.name).toBe(longName);
 		expect(decoder.decode(entries[0].data)).toBe("hello\n");
-	});
-
-	it("extracts a gnu format tar", async () => {
-		const buffer = await fs.readFile(GNU_TAR);
-		const entries = await unpackTar(buffer);
-
-		expect(entries).toHaveLength(1);
-		const [entry] = entries;
-
-		expect(entry.header.name).toBe("test.txt");
-		expect(entry.header.size).toBe(14);
-		expect(entry.header.uid).toBe(12345);
-		expect(entry.header.gid).toBe(67890);
-		expect(entry.header.uname).toBe("myuser");
-		expect(entry.header.gname).toBe("mygroup");
-		expect(decoder.decode(entry.data)).toBe("Hello, world!\n");
 	});
 
 	it("throws an error for an incomplete archive", async () => {

--- a/tests/web/gnu.test.ts
+++ b/tests/web/gnu.test.ts
@@ -1,0 +1,70 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+import { FLAGTYPE, TYPEFLAG } from "../../src/web/constants";
+import { unpackTar } from "../../src/web/index";
+import { decoder } from "../../src/web/utils";
+import { GNU_INCREMENTAL_TAR, GNU_LONG_PATH, GNU_TAR } from "./fixtures";
+
+describe("GNU format support", () => {
+	describe("basic GNU format", () => {
+		it("extracts a gnu format tar", async () => {
+			const buffer = await readFile(GNU_TAR);
+			const entries = await unpackTar(buffer);
+
+			expect(entries).toHaveLength(1);
+			const [entry] = entries;
+
+			expect(entry.header.name).toBe("test.txt");
+			expect(entry.header.size).toBe(14);
+			expect(entry.header.uid).toBe(12345);
+			expect(entry.header.gid).toBe(67890);
+			expect(entry.header.uname).toBe("myuser");
+			expect(entry.header.gname).toBe("mygroup");
+
+			const content = decoder.decode(entry.data).trim();
+			expect(content).toBe("Hello, world!");
+		});
+
+		it("correctly parses GNU incremental format archives", async () => {
+			const buffer = await readFile(GNU_INCREMENTAL_TAR);
+			const entries = await unpackTar(buffer);
+
+			expect(entries).toHaveLength(1);
+			const entry = entries[0];
+
+			expect(entry.header.name).toBe("test.txt");
+			expect(entry.header.type).toBe("file");
+			expect(entry.header.uid).toBe(12345);
+			expect(entry.header.gid).toBe(67890);
+			expect(entry.header.uname).toBe("myuser");
+			expect(entry.header.gname).toBe("mygroup");
+
+			const content = decoder.decode(entry.data).trim();
+			expect(content).toBe("Hello, world!");
+		});
+	});
+
+	describe("GNU long filename support", () => {
+		it("correctly parses GNU long path archives", async () => {
+			const buffer = await readFile(GNU_LONG_PATH);
+			const entries = await unpackTar(buffer);
+
+			expect(entries).toHaveLength(1);
+
+			const entry = entries[0];
+			const expectedLongName =
+				"node-v0.11.14/deps/npm/node_modules/init-package-json/node_modules/promzard/example/npm-init/init-input.js";
+
+			// Verify the long filename was correctly parsed (not truncated)
+			expect(entry.header.name).toBe(expectedLongName);
+			expect(entry.header.name.length).toBeGreaterThan(100); // Exceeds USTAR limit
+			expect(entry.header.type).toBe("file");
+
+			// Verify file content is accessible
+			const content = decoder.decode(entry.data);
+			expect(content).toContain("var fs = require('fs')");
+			expect(content).toContain("module.exports");
+			expect(content).toContain("prompt('name'");
+		});
+	});
+});


### PR DESCRIPTION
While we already supported regular GNU, we didn't support the long filename extensions or the incremental format.

This PR adds support for that. Although the diff looks big, it's just because of a new scoped indent, but most of the logic is the same due to refactor in #28.