### PR TITLE
fix(ustar): explicitly handle unsupported header types

### DIFF
--- a/src/fs/unpack.ts
+++ b/src/fs/unpack.ts
@@ -213,10 +213,8 @@ export function unpackTar(
 						break;
 					}
 
-					case "character-device":
-					case "block-device":
-					case "fifo": {
-						// Unsupported type, skip it.
+					default: {
+						// Unsupported type, skip it. Handles "character-device", "block-device", "fifo", etc.
 						await entry.body.cancel();
 						break;
 					}

--- a/src/fs/unpack.ts
+++ b/src/fs/unpack.ts
@@ -212,6 +212,14 @@ export function unpackTar(
 						await fs.link(resolvedLinkTarget, outPath);
 						break;
 					}
+
+					case "character-device":
+					case "block-device":
+					case "fifo": {
+						// Unsupported type, skip it.
+						await entry.body.cancel();
+						break;
+					}
 				}
 
 				// Apply timestamps if available

--- a/src/web/constants.ts
+++ b/src/web/constants.ts
@@ -36,7 +36,10 @@ export const TYPEFLAG = {
 	file: "0",
 	link: "1",
 	symlink: "2",
+	"character-device": "3",
+	"block-device": "4",
 	directory: "5",
+	fifo: "6",
 	// POSIX.1-2001 extensions
 	"pax-header": "x",
 	"pax-global-header": "g",
@@ -50,7 +53,10 @@ export const FLAGTYPE = {
 	"0": "file",
 	"1": "link",
 	"2": "symlink",
+	"3": "character-device",
+	"4": "block-device",
 	"5": "directory",
+	"6": "fifo",
 	// POSIX.1-2001 extensions
 	x: "pax-header",
 	g: "pax-global-header",

--- a/tests/web/pack.test.ts
+++ b/tests/web/pack.test.ts
@@ -279,4 +279,61 @@ describe("pack", () => {
 			/Unsupported content type/,
 		);
 	});
+
+	it("packs and parses special file types correctly", async () => {
+		const entries: TarEntry[] = [
+			{
+				header: {
+					name: "regular-file.txt",
+					size: 5,
+					type: "file",
+				},
+				body: "hello",
+			},
+			{
+				header: {
+					name: "char-device",
+					size: 0,
+					type: "character-device",
+				},
+			},
+			{
+				header: {
+					name: "block-device",
+					size: 0,
+					type: "block-device",
+				},
+			},
+			{
+				header: {
+					name: "fifo-pipe",
+					size: 0,
+					type: "fifo",
+				},
+			},
+		];
+
+		const packedBuffer = await packTar(entries);
+
+		// Verify all entries are parsed correctly with their types preserved
+		const extracted = await unpackTar(packedBuffer);
+		expect(extracted).toHaveLength(4);
+
+		expect(extracted[0].header.name).toBe("regular-file.txt");
+		expect(extracted[0].header.type).toBe("file");
+		expect(extracted[0].header.size).toBe(5);
+		expect(decoder.decode(extracted[0].data)).toBe("hello");
+
+		expect(extracted[1].header.name).toBe("char-device");
+		expect(extracted[1].header.type).toBe("character-device");
+		expect(extracted[1].header.size).toBe(0);
+
+		expect(extracted[2].header.name).toBe("block-device");
+		expect(extracted[2].header.type).toBe("block-device");
+		expect(extracted[2].header.size).toBe(0);
+
+		expect(extracted[3].header.name).toBe("fifo-pipe");
+		expect(extracted[3].header.type).toBe("fifo");
+		expect(extracted[3].header.size).toBe(0);
+	});
 });


### PR DESCRIPTION
This explicitly handles unsupported file type headers and skips them in the stream.