### PR TITLE
feat(pack): fallback to pax if any ustar limit is hit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 .mise.toml
 *.tsbuildinfo
 coverage
+AGENT.md

--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,14 @@
 {
 	"$schema": "https://biomejs.dev/schemas/2.2.4/schema.json",
 	"files": {
-		"includes": ["**", "!**/dist", "!**/node_modules", "!.git", "!**/fixtures"]
+		"includes": [
+			"**",
+			"!**/dist",
+			"!**/node_modules",
+			"!.git",
+			"!**/fixtures",
+			"!**/coverage"
+		]
 	},
 	"formatter": {
 		"enabled": true

--- a/src/web/constants.ts
+++ b/src/web/constants.ts
@@ -31,6 +31,12 @@ export const USTAR = {
 /** USTAR version ("00"). */
 export const USTAR_VERSION = "00";
 
+/** USTAR max value in 8-byte octal field. */
+export const USTAR_MAX_UID_GID = 0o7777777;
+
+/** USTAR max value in 12-byte octal field (~8GB). */
+export const USTAR_MAX_SIZE = 0o77777777777;
+
 /** Type flag constants for file types. */
 export const TYPEFLAG = {
 	file: "0",

--- a/src/web/pack-pax.ts
+++ b/src/web/pack-pax.ts
@@ -1,0 +1,123 @@
+import { USTAR, USTAR_MAX_SIZE, USTAR_MAX_UID_GID } from "./constants";
+import { createTarHeader } from "./pack";
+import type { TarHeader } from "./types";
+import { encoder } from "./utils";
+
+// Checks a tar header for fields that exceed USTAR limits and generates a PAX header entry if necessary.
+export function generatePax(header: TarHeader): {
+	paxHeader: Uint8Array;
+	paxBody: Uint8Array;
+} | null {
+	const paxRecords: Record<string, string> = {};
+
+	// Check max filename length.
+	if (header.name.length > USTAR.name.size) {
+		const split = findUstarSplit(header.name);
+
+		// If a valid USTAR split is not possible, we must use a PAX record.
+		if (split === null) {
+			paxRecords.path = header.name;
+		}
+	}
+
+	// Check max linkname length.
+	if (header.linkname && header.linkname.length > USTAR.name.size) {
+		paxRecords.linkpath = header.linkname;
+	}
+
+	// Check user/group names.
+	if (header.uname && header.uname.length > USTAR.uname.size) {
+		paxRecords.uname = header.uname;
+	}
+
+	if (header.gname && header.gname.length > USTAR.gname.size) {
+		paxRecords.gname = header.gname;
+	}
+
+	// Check UID/GID values.
+	if (header.uid != null && header.uid > USTAR_MAX_UID_GID) {
+		paxRecords.uid = String(header.uid);
+	}
+
+	if (header.gid != null && header.gid > USTAR_MAX_UID_GID) {
+		paxRecords.gid = String(header.gid);
+	}
+
+	// Check file size.
+	if (header.size != null && header.size > USTAR_MAX_SIZE) {
+		paxRecords.size = String(header.size);
+	}
+
+	// Add any user-provided PAX attributes.
+	if (header.pax) {
+		Object.assign(paxRecords, header.pax);
+	}
+
+	const paxEntries = Object.entries(paxRecords);
+
+	// If no PAX records were generated, we're done.
+	if (paxEntries.length === 0) {
+		return null;
+	}
+
+	// Else, format PAX records into a string.
+	const paxRecordsString = paxEntries
+		.map(([key, value]) => {
+			const record = `${key}=${value}\n`;
+			// The PAX record length includes the length of the length-prefix itself.
+			let length = record.length + 1; // +1 for the space
+			const lengthOfLength = String(length).length;
+			length += lengthOfLength;
+
+			// Re-check if adding the length prefix's length changed its own number of digits.
+			if (String(length).length !== lengthOfLength) {
+				length++;
+			}
+
+			return `${length} ${record}`;
+		})
+		.join("");
+
+	const paxBody = encoder.encode(paxRecordsString);
+
+	const paxHeader = createTarHeader({
+		name: `PaxHeader/${header.name}`.slice(0, 100),
+		size: paxBody.length,
+		type: "pax-header",
+		mode: 0o644,
+		mtime: header.mtime,
+		uname: header.uname,
+		gname: header.gname,
+		uid: header.uid,
+		gid: header.gid,
+	});
+
+	return { paxHeader, paxBody };
+}
+
+// Attempts to split a long path into a USTAR-compatible name and prefix.
+export function findUstarSplit(
+	path: string,
+): { name: string; prefix: string } | null {
+	// No split needed if the path already fits in the name field.
+	if (path.length <= USTAR.name.size) {
+		return null;
+	}
+
+	// For the name part to fit, the slash must be at or after this index.
+	const minSlashIndex = path.length - USTAR.name.size - 1;
+
+	// Find the rightmost slash that respects the prefix length limit (155).
+	const slashIndex = path.lastIndexOf("/", USTAR.prefix.size);
+
+	// A valid split exists if we found a slash (index > 0) and it also
+	// satisfies the minimum index required for the name part to fit.
+	if (slashIndex > 0 && slashIndex >= minSlashIndex) {
+		return {
+			prefix: path.slice(0, slashIndex),
+			name: path.slice(slashIndex + 1),
+		};
+	}
+
+	return null; // No valid split point found.
+}

--- a/tests/fs/pack.test.ts
+++ b/tests/fs/pack.test.ts
@@ -103,6 +103,29 @@ describe("pack", () => {
 		expect(content).toBe("long path test");
 	});
 
+	it("handles PAX long filenames on a round trip", async () => {
+		// This filename has a component longer than 100 chars and cannot use USTAR prefixing.
+		const longFileName =
+			"a-very-long-directory-name-that-is-well-over-one-hundred-characters-long-and-cannot-be-split-easily/file.txt";
+
+		const sourceDir = path.join(tmpDir, "source");
+		const longPathDir = path.join(sourceDir, path.dirname(longFileName));
+		const fullPath = path.join(sourceDir, longFileName);
+
+		await fs.mkdir(longPathDir, { recursive: true });
+		await fs.writeFile(fullPath, "pax path test");
+
+		const destDir = path.join(tmpDir, "extracted");
+		const packStream = packTar(sourceDir);
+		const unpackStream = unpackTar(destDir);
+
+		await pipeline(packStream, unpackStream);
+
+		const extractedFile = path.join(destDir, longFileName);
+		const content = await fs.readFile(extractedFile, "utf-8");
+		expect(content).toBe("pax path test");
+	});
+
 	it("filters entries on pack", async () => {
 		const sourceDir = path.join(FIXTURES_DIR, "c");
 		const destDir = path.join(tmpDir, "extracted");

--- a/tests/web/gnu.test.ts
+++ b/tests/web/gnu.test.ts
@@ -1,6 +1,6 @@
 import { readFile } from "node:fs/promises";
 import { describe, expect, it } from "vitest";
-import { FLAGTYPE, TYPEFLAG } from "../../src/web/constants";
+
 import { unpackTar } from "../../src/web/index";
 import { decoder } from "../../src/web/utils";
 import { GNU_INCREMENTAL_TAR, GNU_LONG_PATH, GNU_TAR } from "./fixtures";

--- a/tests/web/pack-pax.test.ts
+++ b/tests/web/pack-pax.test.ts
@@ -1,0 +1,374 @@
+import { describe, expect, it } from "vitest";
+import { packTar, type TarEntry, unpackTar } from "../../src/web";
+import { generatePax } from "../../src/web/pack-pax";
+import { decoder } from "../../src/web/utils";
+
+describe("PAX format support", () => {
+	it("uses PAX for filename > 100 chars", async () => {
+		// Use a filename that cannot be split e.g. component > 155 chars
+		const longComponent = "a".repeat(200);
+		const fileName = `${longComponent}/test.txt`;
+
+		const entries: TarEntry[] = [
+			{
+				header: { name: fileName, size: 4 },
+				body: "pax!",
+			},
+		];
+
+		const buffer = await packTar(entries);
+		const extracted = await unpackTar(buffer);
+
+		expect(extracted).toHaveLength(1);
+		expect(extracted[0].header.name).toBe(fileName);
+		expect(extracted[0].header.pax?.path).toBe(fileName);
+		expect(decoder.decode(extracted[0].data)).toBe("pax!");
+	});
+
+	it("uses PAX for total filename > 255 chars", async () => {
+		const longPath = `${"a/".repeat(130)}test.txt`; // 261 chars
+		expect(longPath.length).toBeGreaterThan(255);
+
+		const entries: TarEntry[] = [
+			{
+				header: { name: longPath, size: 4 },
+				body: "pax!",
+			},
+		];
+
+		const buffer = await packTar(entries);
+		const extracted = await unpackTar(buffer);
+
+		expect(extracted).toHaveLength(1);
+		expect(extracted[0].header.name).toBe(longPath);
+		expect(extracted[0].header.pax?.path).toBe(longPath);
+	});
+
+	it("uses PAX for long linkname", async () => {
+		const longLink = "a".repeat(150);
+		const entries: TarEntry[] = [
+			{
+				header: {
+					name: "my-symlink",
+					type: "symlink",
+					linkname: longLink,
+					size: 0,
+				},
+			},
+		];
+
+		const buffer = await packTar(entries);
+		const extracted = await unpackTar(buffer);
+
+		expect(extracted).toHaveLength(1);
+		expect(extracted[0].header.linkname).toBe(longLink);
+		expect(extracted[0].header.pax?.linkpath).toBe(longLink);
+	});
+
+	it("uses PAX for large UID/GID", async () => {
+		const largeId = 0o10000000; // Larger than 7777777
+		const entries: TarEntry[] = [
+			{
+				header: { name: "file.txt", size: 4, uid: largeId, gid: largeId },
+				body: "test",
+			},
+		];
+
+		const buffer = await packTar(entries);
+		const extracted = await unpackTar(buffer);
+
+		expect(extracted).toHaveLength(1);
+		expect(extracted[0].header.uid).toBe(largeId);
+		expect(extracted[0].header.gid).toBe(largeId);
+		expect(extracted[0].header.pax?.uid).toBe(largeId.toString());
+		expect(extracted[0].header.pax?.gid).toBe(largeId.toString());
+	});
+
+	it("uses PAX for large file size (> 8GB)", async () => {
+		const largeSize = 0o100000000000; // ~8.5GB
+
+		// Test the PAX generation directly
+		const paxData = generatePax({ name: "large-file.bin", size: largeSize });
+
+		expect(paxData).not.toBeNull();
+		if (paxData) {
+			expect(paxData.paxHeader).toBeDefined();
+			expect(paxData.paxBody).toBeDefined();
+
+			// Verify the PAX record contains the size
+			const paxBodyText = new TextDecoder().decode(paxData.paxBody);
+			expect(paxBodyText).toContain(`size=${largeSize}`);
+		}
+	});
+
+	it("uses PAX for long uname/gname", async () => {
+		const longUname = "a".repeat(33);
+		const longGname = "b".repeat(33);
+		const entries: TarEntry[] = [
+			{
+				header: {
+					name: "user-file.txt",
+					size: 4,
+					uname: longUname,
+					gname: longGname,
+				},
+				body: "test",
+			},
+		];
+
+		const buffer = await packTar(entries);
+		const extracted = await unpackTar(buffer);
+
+		expect(extracted).toHaveLength(1);
+		expect(extracted[0].header.uname).toBe(longUname);
+		expect(extracted[0].header.gname).toBe(longGname);
+		expect(extracted[0].header.pax?.uname).toBe(longUname);
+		expect(extracted[0].header.pax?.gname).toBe(longGname);
+	});
+
+	it("combines multiple PAX attributes", async () => {
+		const longName = "a".repeat(120);
+		const largeId = 0o10000000;
+		const entries: TarEntry[] = [
+			{
+				header: {
+					name: longName,
+					size: 4,
+					uid: largeId,
+				},
+				body: "test",
+			},
+		];
+
+		const buffer = await packTar(entries);
+		const extracted = await unpackTar(buffer);
+
+		expect(extracted).toHaveLength(1);
+		expect(extracted[0].header.name).toBe(longName);
+		expect(extracted[0].header.uid).toBe(largeId);
+		expect(extracted[0].header.pax?.path).toBe(longName);
+		expect(extracted[0].header.pax?.uid).toBe(largeId.toString());
+	});
+
+	it("preserves manually added PAX headers", async () => {
+		const entries: TarEntry[] = [
+			{
+				header: {
+					name: "custom.txt",
+					size: 4,
+					pax: {
+						comment: "this is a custom comment",
+						mtime: "12345.678",
+					},
+				},
+				body: "test",
+			},
+		];
+
+		const buffer = await packTar(entries);
+		const extracted = await unpackTar(buffer);
+
+		expect(extracted).toHaveLength(1);
+		expect(extracted[0].header.pax?.comment).toBe("this is a custom comment");
+		expect(extracted[0].header.mtime).toEqual(new Date(12345.678 * 1000));
+	});
+
+	describe("edge cases", () => {
+		it("handles PAX record length boundary calculation edge case", async () => {
+			// Create a filename that will trigger PAX (must be >100 chars or unsplittable)
+			// Use a long filename without slashes to force PAX usage
+			const craftedName = "x".repeat(200); // Definitely triggers PAX
+
+			const paxData = generatePax({ name: craftedName, size: 4 });
+
+			expect(paxData).not.toBeNull();
+			if (paxData) {
+				const paxBodyText = new TextDecoder().decode(paxData.paxBody);
+				expect(paxBodyText).toContain(`path=${craftedName}`);
+
+				// Verify the PAX record format is correct
+				const lines = paxBodyText.split("\n").filter((line) => line.trim());
+				expect(lines.length).toBeGreaterThan(0);
+
+				// Each line should start with its length followed by a space
+				for (const line of lines) {
+					const spaceIndex = line.indexOf(" ");
+					expect(spaceIndex).toBeGreaterThan(0);
+					const declaredLength = Number.parseInt(
+						line.substring(0, spaceIndex),
+						10,
+					);
+					expect(declaredLength).toBe(line.length + 1); // +1 for the newline
+				}
+			}
+		});
+
+		it("handles PAX record length digit boundary edge case specifically", async () => {
+			// Target records around 96-99 chars to test 99->100 digit boundary
+			const testCases = [
+				// This will create multiple PAX records, some hitting boundaries
+				{
+					name: "a".repeat(200),
+					pax: {
+						// Craft comments of specific lengths to hit boundaries
+						comment1: "x".repeat(85), // Should create ~96 char record: "96 comment1=" + 85 + "\n"
+						comment2: "y".repeat(87), // Should create ~98 char record
+						comment3: "z".repeat(89), // Should create ~100 char record, testing boundary
+					},
+				},
+			];
+
+			for (const testCase of testCases) {
+				const paxData = generatePax({ ...testCase, size: 0 });
+
+				if (paxData) {
+					const paxBodyText = new TextDecoder().decode(paxData.paxBody);
+					// Verify each record is properly formatted
+					const lines = paxBodyText.split("\n").filter((line) => line.trim());
+					for (const line of lines) {
+						const spaceIndex = line.indexOf(" ");
+						if (spaceIndex > 0) {
+							const declaredLength = parseInt(
+								line.substring(0, spaceIndex),
+								10,
+							);
+							expect(declaredLength).toBe(line.length + 1);
+						}
+					}
+				}
+			}
+		});
+
+		it("handles complex PAX record with multiple boundary conditions", async () => {
+			// Test a scenario with multiple PAX fields that might trigger edge cases
+			const longName = "a".repeat(200); // Triggers path PAX record
+			const longUser = "b".repeat(50); // Triggers uname PAX record
+			const largeUid = 99999999; // Triggers uid PAX record
+
+			const entries: TarEntry[] = [
+				{
+					header: {
+						name: longName,
+						size: 4,
+						type: "file",
+						uname: longUser,
+						uid: largeUid,
+						pax: {
+							// Add custom PAX attributes to test preservation
+							comment: "test comment without special chars",
+							customField: "custom value",
+						},
+					},
+					body: "test",
+				},
+			];
+
+			const buffer = await packTar(entries);
+			const extracted = await unpackTar(buffer);
+
+			expect(extracted).toHaveLength(1);
+			expect(extracted[0].header.name).toBe(longName);
+			expect(extracted[0].header.uname).toBe(longUser);
+			expect(extracted[0].header.uid).toBe(largeUid);
+			expect(extracted[0].header.pax?.path).toBe(longName);
+			expect(extracted[0].header.pax?.uname).toBe(longUser);
+			expect(extracted[0].header.pax?.uid).toBe(largeUid.toString());
+			expect(extracted[0].header.pax?.comment).toBe(
+				"test comment without special chars",
+			);
+			expect(extracted[0].header.pax?.customField).toBe("custom value");
+		});
+
+		it("handles PAX records with special characters and encoding", async () => {
+			const nameWithSpecialChars = "тест-файл-с-русскими-буквами.txt"; // Cyrillic
+			const emojiName = "📁folder/🗂️file-with-emojis.txt"; // Emojis
+
+			const entries: TarEntry[] = [
+				{
+					header: {
+						name: nameWithSpecialChars,
+						size: 4,
+						type: "file",
+					},
+					body: "test",
+				},
+				{
+					header: {
+						name: emojiName,
+						size: 4,
+						type: "file",
+					},
+					body: "test",
+				},
+			];
+
+			const buffer = await packTar(entries);
+			const extracted = await unpackTar(buffer);
+
+			expect(extracted).toHaveLength(2);
+			expect(extracted[0].header.name).toBe(nameWithSpecialChars);
+			expect(extracted[1].header.name).toBe(emojiName);
+		});
+
+		it("handles extremely long PAX records", async () => {
+			// Create a PAX record that's long enough to test edge cases in length calculation
+			const veryLongName = "x".repeat(1000); // Much longer than USTAR limits
+			const veryLongUser = "u".repeat(100);
+			const veryLongGroup = "g".repeat(100);
+
+			const paxData = generatePax({
+				name: veryLongName,
+				uname: veryLongUser,
+				gname: veryLongGroup,
+				size: 4,
+				type: "file",
+			});
+
+			expect(paxData).not.toBeNull();
+			if (paxData) {
+				const paxBodyText = new TextDecoder().decode(paxData.paxBody);
+				expect(paxBodyText).toContain(`path=${veryLongName}`);
+				expect(paxBodyText).toContain(`uname=${veryLongUser}`);
+				expect(paxBodyText).toContain(`gname=${veryLongGroup}`);
+
+				// Verify all PAX records are properly formatted
+				const records = paxBodyText.split("\n").filter((line) => line.trim());
+				for (const record of records) {
+					expect(record).toMatch(/^\d+ \w+=/);
+				}
+			}
+		});
+
+		it("handles bodyless entries with PAX headers", async () => {
+			const longDirName = "a".repeat(200);
+			const longLinkTarget = "b".repeat(200);
+
+			const entries: TarEntry[] = [
+				{
+					header: {
+						name: `${longDirName}/`,
+						type: "directory",
+						size: 0, // Directories have no body
+					},
+				},
+				{
+					header: {
+						name: "link-to-long-target",
+						type: "symlink",
+						linkname: longLinkTarget,
+						size: 0, // Symlinks have no body
+					},
+				},
+			];
+
+			const buffer = await packTar(entries);
+			const extracted = await unpackTar(buffer);
+
+			expect(extracted).toHaveLength(2);
+			expect(extracted[0].header.name).toBe(`${longDirName}/`);
+			expect(extracted[0].header.type).toBe("directory");
+			expect(extracted[1].header.linkname).toBe(longLinkTarget);
+			expect(extracted[1].header.type).toBe("symlink");
+		});
+	});
+});


### PR DESCRIPTION
This adds the ability to automatically detect if any packing action exceeds USTAR limits and automatically falls back to PAX headers. e.g. if the file exceeds 8GB or has filepaths that exceed 255 characters etc.