### PR TITLE
feat(decoder): add strict mode flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ const entries = [
 const tarBuffer = await packTar(entries);
 ```
 
-#### `unpackTar(archive: ArrayBuffer | Uint8Array, options?: UnpackOptions): Promise<ParsedTarEntryWithData[]>`
+#### `unpackTar(archive: ArrayBuffer | Uint8Array | ReadableStream<Uint8Array>, options?: UnpackOptions): Promise<ParsedTarEntryWithData[]>`
 
 Extract all entries from a tar archive buffer with optional filtering and transformation.
 
@@ -287,7 +287,7 @@ const stream2 = controller.add({ name: "file2.txt", size: 4 });
 controller.finalize();
 ```
 
-#### `createTarDecoder(): TransformStream<Uint8Array, ParsedTarEntry>`
+#### `createTarDecoder(options?: DecoderOptions): TransformStream<Uint8Array, ParsedTarEntry>`
 
 Create a transform stream that parses tar bytes into entries.
 
@@ -387,6 +387,7 @@ const tarStream = createReadStream('backup.tar');
 const extractStream = unpackTar('/restore/location', {
   strip: 1,
   fmode: 0o644, // Set consistent file permissions
+  strict: true, // Enable strict validation
 });
 await pipeline(tarStream, extractStream);
 ```
@@ -455,8 +456,13 @@ interface ParsedTarEntryWithData {
 }
 
 // Platform-neutral configuration for unpacking
-interface UnpackOptions {
-  /** Number of leading path components to strip from entry names (e.g., strip: 1 removes first directory) */
+interface DecoderOptions {
+  /** Enable strict validation (e.g., throw on invalid checksums) */
+  strict?: boolean;
+}
+
+interface UnpackOptions extends DecoderOptions {
+	/** Number of leading path components to strip from entry names (e.g., strip: 1 removes first directory) */
   strip?: number;
   /** Filter function to include/exclude entries (return false to skip) */
   filter?: (header: TarHeader) => boolean;

--- a/src/fs/unpack.ts
+++ b/src/fs/unpack.ts
@@ -85,7 +85,7 @@ export function unpackTar(
 		await fs.mkdir(resolvedDestDir, { recursive: true });
 
 		const entryStream = readable
-			.pipeThrough(createTarDecoder())
+			.pipeThrough(createTarDecoder(options))
 			.pipeThrough(createTarOptionsTransformer(options));
 
 		const reader = entryStream.getReader();

--- a/src/web/helpers.ts
+++ b/src/web/helpers.ts
@@ -154,7 +154,7 @@ export async function unpackTar(
 	const results: ParsedTarEntryWithData[] = [];
 
 	const entryStream = sourceStream
-		.pipeThrough(createTarDecoder())
+		.pipeThrough(createTarDecoder(options))
 		.pipeThrough(createTarOptionsTransformer(options));
 
 	const reader = entryStream.getReader();

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -6,6 +6,7 @@ export {
 	type TarPackController,
 } from "./pack";
 export type {
+	DecoderOptions,
 	ParsedTarEntry,
 	ParsedTarEntryWithData,
 	TarEntry,

--- a/src/web/types.ts
+++ b/src/web/types.ts
@@ -68,12 +68,26 @@ export interface ParsedTarEntryWithData {
 }
 
 /**
+ * Configuration options for creating a tar decoder stream.
+ */
+export interface DecoderOptions {
+	/**
+	 * Enable strict validation of the tar archive.
+	 * When true, the decoder will throw errors for data corruption issues:
+	 * - Invalid checksums (indicates header corruption)
+	 * - Invalid USTAR magic string (format violation)
+	 * @default false
+	 */
+	strict?: boolean;
+}
+
+/**
  * Platform-neutral configuration options for extracting tar archives.
  *
  * These options work with any tar extraction implementation and are not tied
  * to specific platforms like Node.js filesystem APIs.
  */
-export interface UnpackOptions {
+export interface UnpackOptions extends DecoderOptions {
 	/** Number of leading path components to strip from entry names (e.g., strip: 1 removes first directory) */
 	strip?: number;
 	/** Filter function to include/exclude entries (return false to skip) */

--- a/tests/web/checksum.test.ts
+++ b/tests/web/checksum.test.ts
@@ -15,7 +15,7 @@ describe("checksum validation", () => {
 		// Corrupt the checksum by changing the first byte
 		buffer[USTAR.checksum.offset] = buffer[USTAR.checksum.offset] + 1;
 
-		await expect(unpackTar(buffer)).rejects.toThrow(
+		await expect(unpackTar(buffer, { strict: true })).rejects.toThrow(
 			"Invalid tar header checksum",
 		);
 	});
@@ -33,7 +33,7 @@ describe("checksum validation", () => {
 			buffer[USTAR.checksum.offset + i] = 0;
 		}
 
-		await expect(unpackTar(buffer)).rejects.toThrow(
+		await expect(unpackTar(buffer, { strict: true })).rejects.toThrow(
 			"Invalid tar header checksum",
 		);
 	});
@@ -49,7 +49,7 @@ describe("checksum validation", () => {
 		// Change the first character of the filename
 		buffer[USTAR.name.offset] = buffer[USTAR.name.offset] + 1;
 
-		await expect(unpackTar(buffer)).rejects.toThrow(
+		await expect(unpackTar(buffer, { strict: true })).rejects.toThrow(
 			"Invalid tar header checksum",
 		);
 	});
@@ -65,7 +65,7 @@ describe("checksum validation", () => {
 		// Corrupt one byte in the size field
 		buffer[USTAR.size.offset] = buffer[USTAR.size.offset] + 1;
 
-		await expect(unpackTar(buffer)).rejects.toThrow(
+		await expect(unpackTar(buffer, { strict: true })).rejects.toThrow(
 			"Invalid tar header checksum",
 		);
 	});
@@ -109,7 +109,7 @@ describe("checksum validation", () => {
 		buffer[secondChecksumOffset] = buffer[secondChecksumOffset] + 1;
 
 		// The entire extraction should fail when encountering the corrupted second entry
-		await expect(unpackTar(buffer)).rejects.toThrow(
+		await expect(unpackTar(buffer, { strict: true })).rejects.toThrow(
 			"Invalid tar header checksum",
 		);
 	});
@@ -124,7 +124,7 @@ describe("checksum validation", () => {
 		// Corrupt the checksum
 		buffer[USTAR.checksum.offset] = buffer[USTAR.checksum.offset] + 1;
 
-		await expect(unpackTar(buffer)).rejects.toThrow(
+		await expect(unpackTar(buffer, { strict: true })).rejects.toThrow(
 			"Invalid tar header checksum",
 		);
 	});

--- a/tests/web/extract.test.ts
+++ b/tests/web/extract.test.ts
@@ -234,7 +234,7 @@ describe("extract", () => {
 
 		// @ts-expect-error ReadableStream.from is supported in tests.
 		const sourceStream = ReadableStream.from([invalidHeader]);
-		const entryStream = sourceStream.pipeThrough(createTarDecoder());
+		const entryStream = sourceStream.pipeThrough(createTarDecoder({ strict: true }));
 		const reader = entryStream.getReader();
 
 		await expect(reader.read()).rejects.toThrow("Invalid tar header checksum");


### PR DESCRIPTION
While trying to integrate this into some other packages, I realise that many real world tar files just don't have the correct checksums in place. That's why alternatives such as `node-tar` don't even validate checksums without a `strict` flag.

This PR adds a new strict mode flag to give the option for `modern-tar` to default on leniency but then optionally be strict if needed.