### PR TITLE
perf: remove number constructor for parseint

### DIFF
--- a/src/web/unpack.ts
+++ b/src/web/unpack.ts
@@ -292,7 +292,7 @@ function parsePax(buffer: Uint8Array): HeaderOverrides {
 		if (spaceIndex === -1) break;
 
 		// The length is the number before the space.
-		const length = Number.parseInt(
+		const length = parseInt(
 			decoder.decode(buffer.subarray(offset, spaceIndex)),
 			10,
 		);
@@ -316,16 +316,16 @@ function parsePax(buffer: Uint8Array): HeaderOverrides {
 					overrides.linkname = value;
 					break;
 				case "size":
-					overrides.size = Number.parseInt(value, 10);
+					overrides.size = parseInt(value, 10);
 					break;
 				case "mtime":
-					overrides.mtime = Number.parseFloat(value);
+					overrides.mtime = parseFloat(value);
 					break;
 				case "uid":
-					overrides.uid = Number.parseInt(value, 10);
+					overrides.uid = parseInt(value, 10);
 					break;
 				case "gid":
-					overrides.gid = Number.parseInt(value, 10);
+					overrides.gid = parseInt(value, 10);
 					break;
 				case "uname":
 					overrides.uname = value;

--- a/src/web/utils.ts
+++ b/src/web/utils.ts
@@ -62,7 +62,7 @@ export function readOctal(
 	const octalString = readString(view, offset, size).trim();
 
 	// An empty or invalid octal string is treated as zero.
-	return octalString ? Number.parseInt(octalString, 8) : 0;
+	return octalString ? parseInt(octalString, 8) : 0;
 }
 
 /**

--- a/tests/web/extract.test.ts
+++ b/tests/web/extract.test.ts
@@ -217,7 +217,7 @@ describe("extract", () => {
 		if (entry) {
 			expect(entry.header.name).toBe("huge.txt");
 			// Verify that the size was correctly parsed from the PAX header
-			expect(entry.header.size).toBe(Number.parseInt(hugeFileSize, 10));
+			expect(entry.header.size).toBe(parseInt(hugeFileSize, 10));
 
 			// Read just a small portion of the body to verify it starts correctly
 			const bodyReader = entry.body.getReader();

--- a/tests/web/pack-pax.test.ts
+++ b/tests/web/pack-pax.test.ts
@@ -194,10 +194,7 @@ describe("PAX format support", () => {
 				for (const line of lines) {
 					const spaceIndex = line.indexOf(" ");
 					expect(spaceIndex).toBeGreaterThan(0);
-					const declaredLength = Number.parseInt(
-						line.substring(0, spaceIndex),
-						10,
-					);
+					const declaredLength = parseInt(line.substring(0, spaceIndex), 10);
 					expect(declaredLength).toBe(line.length + 1); // +1 for the newline
 				}
 			}


### PR DESCRIPTION
It's not needed and can make our bundle size a tiny bit smaller.