### PR TITLE
perf(bundle): only keep tsdocs in dts files

### DIFF
--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -7,5 +7,20 @@ export default defineConfig([
 		dts: {
 			build: true,
 		},
+		plugins: [
+			{
+				name: "strip-tsdoc",
+				generateBundle(_options, bundle) {
+					for (const [fileName, chunk] of Object.entries(bundle)) {
+						if (chunk.type === "chunk" && fileName.endsWith(".js")) {
+							chunk.code = chunk.code.replace(
+								/\n?\s*\/\*\*[\s\S]*?\*\/\s*\n?/g,
+								"\n",
+							);
+						}
+					}
+				},
+			},
+		],
 	},
 ]);


### PR DESCRIPTION
Rolldown was copying the large TSDocs we have in both our `.js` and `.d.ts` files. Stripping the duplicate docs in the `.js` files nets around a 10kb reduction in unpacked package size.