### PR TITLE
perf(pack): use buffer alloc unsafe

### DIFF
--- a/src/fs/pack.ts
+++ b/src/fs/pack.ts
@@ -102,7 +102,7 @@ export function packTar(
 			const paxPadding =
 				(BLOCK_SIZE - (paxData.paxBody.length % BLOCK_SIZE)) % BLOCK_SIZE;
 			if (paxPadding > 0) {
-				yield Buffer.alloc(paxPadding);
+				yield Buffer.allocUnsafe(paxPadding);
 			}
 		}
 
@@ -114,7 +114,7 @@ export function packTar(
 			const paddingSize =
 				(BLOCK_SIZE - (finalHeader.size % BLOCK_SIZE)) % BLOCK_SIZE;
 			if (paddingSize > 0) {
-				yield Buffer.alloc(paddingSize); // Using Buffer.alloc is idiomatic in Node.js
+				yield Buffer.allocUnsafe(paddingSize);
 			}
 		}
 


### PR DESCRIPTION
Small optimisation from `node-tar` that is safe to do because it is guaranteed we are going to write over this buffer.