### PR TITLE
perf: use bitwise operators

### DIFF
--- a/src/web/constants.ts
+++ b/src/web/constants.ts
@@ -1,6 +1,9 @@
 /** Size of a TAR block in bytes. */
 export const BLOCK_SIZE = 512;
 
+/** Bitwise mask for calculating remainders when dividing by BLOCK_SIZE. Equal to BLOCK_SIZE - 1. */
+export const BLOCK_SIZE_MASK = 511;
+
 /** Default permissions for regular files (rw-r--r--). */
 export const DEFAULT_FILE_MODE = 0o644;
 

--- a/src/web/pack.ts
+++ b/src/web/pack.ts
@@ -1,6 +1,7 @@
 import { writeChecksum } from "./checksum";
 import {
 	BLOCK_SIZE,
+	BLOCK_SIZE_MASK,
 	DEFAULT_DIR_MODE,
 	DEFAULT_FILE_MODE,
 	TYPEFLAG,
@@ -144,8 +145,7 @@ export function createTarPacker(): {
 				// @ts-expect-error - TypeScript is overly strict here, but Uint8Array is compatible here.
 				streamController.enqueue(paxData.paxBody);
 
-				const paxPadding =
-					(BLOCK_SIZE - (paxData.paxBody.length % BLOCK_SIZE)) % BLOCK_SIZE;
+				const paxPadding = -paxData.paxBody.length & BLOCK_SIZE_MASK;
 
 				if (paxPadding > 0) {
 					streamController.enqueue(new Uint8Array(paxPadding));
@@ -182,7 +182,7 @@ export function createTarPacker(): {
 					}
 
 					// Pad the entry data to fill a complete 512-byte block.
-					const paddingSize = (BLOCK_SIZE - (size % BLOCK_SIZE)) % BLOCK_SIZE;
+					const paddingSize = -size & BLOCK_SIZE_MASK;
 					if (paddingSize > 0) {
 						streamController.enqueue(new Uint8Array(paddingSize));
 					}


### PR DESCRIPTION
Minor micro-optimisation to improve performance and reduce bundle size.