### PR TITLE
perf(pack): use file readdir with file types to skip syscall

### DIFF
--- a/src/fs/unpack.ts
+++ b/src/fs/unpack.ts
@@ -118,8 +118,7 @@ export function unpackTar(
 					case "file": {
 						// For < 32kb files, buffer the content and use writeFile to avoid overhead of creating a stream.
 						if (header.size <= 32 * 1024) {
-							const data = await streamToBuffer(entry.body);
-							await fs.writeFile(outPath, data, {
+							await fs.writeFile(outPath, await streamToBuffer(entry.body), {
 								mode: options.fmode ?? header.mode,
 							});
 						} else {


### PR DESCRIPTION
This lets us skip `stat` calls since `readdir` can fetch that for us in advance. Also a bunch of micro-optimisations to reduce our bundle size and unpacked package size.