### PR TITLE
perf(util): micro optimizations and inlining

### DIFF
--- a/src/web/checksum.ts
+++ b/src/web/checksum.ts
@@ -30,7 +30,6 @@ export function validateChecksum(block: Uint8Array): boolean {
 
 /**
  * Calculates and writes the checksum directly to the block.
- * This version uses bitwise operations for performance and avoids allocations.
  */
 export function writeChecksum(block: Uint8Array): void {
 	// Fill with spaces for the calculation.

--- a/src/web/checksum.ts
+++ b/src/web/checksum.ts
@@ -10,11 +10,7 @@ const ASCII_ZERO = 48; // '0'
  * Validates the checksum of a tar header block.
  */
 export function validateChecksum(block: Uint8Array): boolean {
-	const stored = readOctal(
-		block,
-		USTAR.checksum.offset,
-		USTAR.checksum.size,
-	);
+	const stored = readOctal(block, USTAR.checksum.offset, USTAR.checksum.size);
 
 	let sum = 0;
 	for (let i = 0; i < block.length; i++) {

--- a/src/web/utils.ts
+++ b/src/web/utils.ts
@@ -30,7 +30,7 @@ export function writeOctal(
 	// Format to an octal string, pad with leading zeros to size - 1.
 	// The final byte is left as 0 (NUL terminator), assuming a zero-filled view.
 	const octalString = value.toString(8).padStart(size - 1, "0");
-	writeString(view, offset, size - 1, octalString);
+	encoder.encodeInto(octalString, view.subarray(offset, offset + size - 1));
 }
 
 /**
@@ -41,14 +41,12 @@ export function readString(
 	offset: number,
 	size: number,
 ): string {
-	const slice = view.subarray(offset, offset + size);
-	const nullIndex = slice.indexOf(0);
+	// Find the first NUL byte within the specified size.
+	const end = view.indexOf(0, offset);
 
-	// Decode up to the first NUL char, or the full slice if no NUL is found.
-	const effectiveSlice =
-		nullIndex === -1 ? slice : slice.subarray(0, nullIndex);
-
-	return decoder.decode(effectiveSlice);
+	// If no NUL found, read the entire size.
+	const sliceEnd = end === -1 || end > offset + size ? offset + size : end;
+	return decoder.decode(view.subarray(offset, sliceEnd));
 }
 
 /**
@@ -59,10 +57,17 @@ export function readOctal(
 	offset: number,
 	size: number,
 ): number {
-	const octalString = readString(view, offset, size).trim();
+	let value = 0;
+	const end = offset + size;
 
-	// An empty or invalid octal string is treated as zero.
-	return octalString ? parseInt(octalString, 8) : 0;
+	for (let i = offset; i < end; i++) {
+		const charCode = view[i];
+		if (charCode === 0) break; // Stop at NUL terminator
+		if (charCode === 32) continue; // Ignore whitespace
+		value = (value << 3) + (charCode - 48); // 48 is ASCII '0'
+	}
+
+	return value;
 }
 
 /**
@@ -74,22 +79,13 @@ export function readNumeric(
 	offset: number,
 	size: number,
 ): number {
-	// POSIX base-256 encoding uses the high bit of the first byte to indicate
-	// that the field is in base-256.
 	if (view[offset] & 0x80) {
-		let result = view[offset] & 0x7f; // Handle the first byte separately, clearing the high bit.
-
-		// Start loop from the second byte.
-		for (let i = 1; i < size; i++) {
-			// (result << 8) is equivalent to (result * 256) but faster.
-			// | view[offset + i] is equivalent to + view[offset + i] for positive numbers.
+		let result = 0;
+		for (let i = 0; i < size; i++) {
 			result = (result << 8) | view[offset + i];
 		}
-
-		return result;
+		return result & ~(0x80 << ((size - 1) * 8));
 	}
-
-	// Fallback to standard octal parsing.
 	return readOctal(view, offset, size);
 }
 


### PR DESCRIPTION
More micro-optimisations to help reduce bundle size and improve performance. And a bitwise operator fix at the end to ensure numbers remain positive and not underflow.