### PR TITLE
perf: do not use object lookup for ustar constant

### DIFF
--- a/src/web/checksum.ts
+++ b/src/web/checksum.ts
@@ -30,7 +30,6 @@ export function validateChecksum(block: Uint8Array): boolean {
 
 /**
  * Calculates and writes the checksum directly to the block.
- * This version uses bitwise operations for performance and avoids allocations.
  */
 export function writeChecksum(block: Uint8Array): void {
 	// Fill with spaces for the calculation.

--- a/src/web/checksum.ts
+++ b/src/web/checksum.ts
@@ -10,11 +10,7 @@ const ASCII_ZERO = 48; // '0'
  * Validates the checksum of a tar header block.
  */
 export function validateChecksum(block: Uint8Array): boolean {
-	const stored = readOctal(
-		block,
-		USTAR.checksum.offset,
-		USTAR.checksum.size,
-	);
+	const stored = readOctal(block, USTAR.checksum.offset, USTAR.checksum.size);
 
 	let sum = 0;
 	for (let i = 0; i < block.length; i++) {

--- a/src/web/checksum.ts
+++ b/src/web/checksum.ts
@@ -1,4 +1,4 @@
-import { USTAR } from "./constants";
+import { USTAR_CHECKSUM_OFFSET, USTAR_CHECKSUM_SIZE } from "./constants";
 import { readOctal } from "./utils";
 
 // ASCII code for a space character.
@@ -10,14 +10,14 @@ const ASCII_ZERO = 48; // '0'
  * Validates the checksum of a tar header block.
  */
 export function validateChecksum(block: Uint8Array): boolean {
-	const stored = readOctal(block, USTAR.checksum.offset, USTAR.checksum.size);
+	const stored = readOctal(block, USTAR_CHECKSUM_OFFSET, USTAR_CHECKSUM_SIZE);
 
 	let sum = 0;
 	for (let i = 0; i < block.length; i++) {
 		// If the byte is part of the checksum field, treat it as a space.
 		if (
-			i >= USTAR.checksum.offset &&
-			i < USTAR.checksum.offset + USTAR.checksum.size
+			i >= USTAR_CHECKSUM_OFFSET &&
+			i < USTAR_CHECKSUM_OFFSET + USTAR_CHECKSUM_SIZE
 		) {
 			sum += CHECKSUM_SPACE;
 		} else {
@@ -35,8 +35,8 @@ export function writeChecksum(block: Uint8Array): void {
 	// Fill with spaces for the calculation.
 	block.fill(
 		CHECKSUM_SPACE,
-		USTAR.checksum.offset,
-		USTAR.checksum.offset + USTAR.checksum.size,
+		USTAR_CHECKSUM_OFFSET,
+		USTAR_CHECKSUM_OFFSET + USTAR_CHECKSUM_SIZE,
 	);
 
 	// Sum the entire block to get the checksum value.
@@ -47,12 +47,12 @@ export function writeChecksum(block: Uint8Array): void {
 
 	// Write checksum as a 6-digit octal string directly into the block.
 	// We work backwards from the last digit's position.
-	for (let i = USTAR.checksum.offset + 6 - 1; i >= USTAR.checksum.offset; i--) {
+	for (let i = USTAR_CHECKSUM_OFFSET + 6 - 1; i >= USTAR_CHECKSUM_OFFSET; i--) {
 		block[i] = (checksum & 7) + ASCII_ZERO; // (checksum % 8)
 		checksum >>= 3; // Math.floor(checksum / 8)
 	}
 
 	// Add the required NUL and space terminators.
-	block[USTAR.checksum.offset + 6] = 0;
-	block[USTAR.checksum.offset + 7] = CHECKSUM_SPACE;
+	block[USTAR_CHECKSUM_OFFSET + 6] = 0;
+	block[USTAR_CHECKSUM_OFFSET + 7] = CHECKSUM_SPACE;
 }

--- a/src/web/constants.ts
+++ b/src/web/constants.ts
@@ -14,22 +14,62 @@ export const DEFAULT_DIR_MODE = 0o755;
  *
  * @see https://www.gnu.org/software/tar/manual/html_node/Standard.html
  */
-export const USTAR = {
-	name: { offset: 0, size: 100 },
-	mode: { offset: 100, size: 8 },
-	uid: { offset: 108, size: 8 },
-	gid: { offset: 116, size: 8 },
-	size: { offset: 124, size: 12 },
-	mtime: { offset: 136, size: 12 },
-	checksum: { offset: 148, size: 8 },
-	typeflag: { offset: 156, size: 1 },
-	linkname: { offset: 157, size: 100 },
-	magic: { offset: 257, size: 6 },
-	version: { offset: 263, size: 2 },
-	uname: { offset: 265, size: 32 },
-	gname: { offset: 297, size: 32 },
-	prefix: { offset: 345, size: 155 },
-} as const;
+
+// Name field
+export const USTAR_NAME_OFFSET = 0;
+export const USTAR_NAME_SIZE = 100;
+
+// Mode field
+export const USTAR_MODE_OFFSET = 100;
+export const USTAR_MODE_SIZE = 8;
+
+// UID field
+export const USTAR_UID_OFFSET = 108;
+export const USTAR_UID_SIZE = 8;
+
+// GID field
+export const USTAR_GID_OFFSET = 116;
+export const USTAR_GID_SIZE = 8;
+
+// Size field
+export const USTAR_SIZE_OFFSET = 124;
+export const USTAR_SIZE_SIZE = 12;
+
+// Mtime field
+export const USTAR_MTIME_OFFSET = 136;
+export const USTAR_MTIME_SIZE = 12;
+
+// Checksum field
+export const USTAR_CHECKSUM_OFFSET = 148;
+export const USTAR_CHECKSUM_SIZE = 8;
+
+// Typeflag field
+export const USTAR_TYPEFLAG_OFFSET = 156;
+export const USTAR_TYPEFLAG_SIZE = 1;
+
+// Linkname field
+export const USTAR_LINKNAME_OFFSET = 157;
+export const USTAR_LINKNAME_SIZE = 100;
+
+// Magic field
+export const USTAR_MAGIC_OFFSET = 257;
+export const USTAR_MAGIC_SIZE = 6;
+
+// Version field
+export const USTAR_VERSION_OFFSET = 263;
+export const USTAR_VERSION_SIZE = 2;
+
+// Uname field
+export const USTAR_UNAME_OFFSET = 265;
+export const USTAR_UNAME_SIZE = 32;
+
+// Gname field
+export const USTAR_GNAME_OFFSET = 297;
+export const USTAR_GNAME_SIZE = 32;
+
+// Prefix field
+export const USTAR_PREFIX_OFFSET = 345;
+export const USTAR_PREFIX_SIZE = 155;
 
 /** USTAR version ("00"). */
 export const USTAR_VERSION = "00";

--- a/src/web/pack-pax.ts
+++ b/src/web/pack-pax.ts
@@ -1,4 +1,4 @@
-import { USTAR, USTAR_MAX_SIZE, USTAR_MAX_UID_GID } from "./constants";
+import { USTAR_NAME_SIZE, USTAR_UNAME_SIZE, USTAR_GNAME_SIZE, USTAR_PREFIX_SIZE, USTAR_MAX_SIZE, USTAR_MAX_UID_GID } from "./constants";
 import { createTarHeader } from "./pack";
 import type { TarHeader } from "./types";
 import { decoder, encoder } from "./utils";
@@ -11,7 +11,7 @@ export function generatePax(header: TarHeader): {
 	const paxRecords: Record<string, string> = {};
 
 	// Check max filename length.
-	if (header.name.length > USTAR.name.size) {
+	if (header.name.length > USTAR_NAME_SIZE) {
 		const split = findUstarSplit(header.name);
 
 		// If a valid USTAR split is not possible, we must use a PAX record.
@@ -21,16 +21,16 @@ export function generatePax(header: TarHeader): {
 	}
 
 	// Check max linkname length.
-	if (header.linkname && header.linkname.length > USTAR.name.size) {
+	if (header.linkname && header.linkname.length > USTAR_NAME_SIZE) {
 		paxRecords.linkpath = header.linkname;
 	}
 
 	// Check user/group names.
-	if (header.uname && header.uname.length > USTAR.uname.size) {
+	if (header.uname && header.uname.length > USTAR_UNAME_SIZE) {
 		paxRecords.uname = header.uname;
 	}
 
-	if (header.gname && header.gname.length > USTAR.gname.size) {
+	if (header.gname && header.gname.length > USTAR_GNAME_SIZE) {
 		paxRecords.gname = header.gname;
 	}
 
@@ -103,15 +103,15 @@ export function findUstarSplit(
 	path: string,
 ): { name: string; prefix: string } | null {
 	// No split needed if the path already fits in the name field.
-	if (path.length <= USTAR.name.size) {
+	if (path.length <= USTAR_NAME_SIZE) {
 		return null;
 	}
 
 	// For the name part to fit, the slash must be at or after this index.
-	const minSlashIndex = path.length - USTAR.name.size - 1;
+	const minSlashIndex = path.length - USTAR_NAME_SIZE - 1;
 
 	// Find the rightmost slash that respects the prefix length limit (155).
-	const slashIndex = path.lastIndexOf("/", USTAR.prefix.size);
+	const slashIndex = path.lastIndexOf("/", USTAR_PREFIX_SIZE);
 
 	// A valid split exists if we found a slash and it allows both parts to fit.
 	if (slashIndex > 0 && slashIndex >= minSlashIndex) {

--- a/src/web/pack.ts
+++ b/src/web/pack.ts
@@ -5,7 +5,32 @@ import {
 	DEFAULT_DIR_MODE,
 	DEFAULT_FILE_MODE,
 	TYPEFLAG,
-	USTAR,
+	USTAR_NAME_OFFSET,
+	USTAR_NAME_SIZE,
+	USTAR_MODE_OFFSET,
+	USTAR_MODE_SIZE,
+	USTAR_UID_OFFSET,
+	USTAR_UID_SIZE,
+	USTAR_GID_OFFSET,
+	USTAR_GID_SIZE,
+	USTAR_SIZE_OFFSET,
+	USTAR_SIZE_SIZE,
+	USTAR_MTIME_OFFSET,
+	USTAR_MTIME_SIZE,
+	USTAR_TYPEFLAG_OFFSET,
+	USTAR_TYPEFLAG_SIZE,
+	USTAR_LINKNAME_OFFSET,
+	USTAR_LINKNAME_SIZE,
+	USTAR_MAGIC_OFFSET,
+	USTAR_MAGIC_SIZE,
+	USTAR_VERSION_OFFSET,
+	USTAR_VERSION_SIZE,
+	USTAR_UNAME_OFFSET,
+	USTAR_UNAME_SIZE,
+	USTAR_GNAME_OFFSET,
+	USTAR_GNAME_SIZE,
+	USTAR_PREFIX_OFFSET,
+	USTAR_PREFIX_SIZE,
 	USTAR_VERSION,
 } from "./constants";
 import { findUstarSplit, generatePax } from "./pack-pax";
@@ -233,41 +258,41 @@ export function createTarHeader(header: TarHeader): Uint8Array {
 		}
 	}
 
-	writeString(view, USTAR.name.offset, USTAR.name.size, name);
+	writeString(view, USTAR_NAME_OFFSET, USTAR_NAME_SIZE, name);
 	writeOctal(
 		view,
-		USTAR.mode.offset,
-		USTAR.mode.size,
+		USTAR_MODE_OFFSET,
+		USTAR_MODE_SIZE,
 		header.mode ??
 			(header.type === "directory" ? DEFAULT_DIR_MODE : DEFAULT_FILE_MODE),
 	);
-	writeOctal(view, USTAR.uid.offset, USTAR.uid.size, header.uid ?? 0);
-	writeOctal(view, USTAR.gid.offset, USTAR.gid.size, header.gid ?? 0);
-	writeOctal(view, USTAR.size.offset, USTAR.size.size, size);
+	writeOctal(view, USTAR_UID_OFFSET, USTAR_UID_SIZE, header.uid ?? 0);
+	writeOctal(view, USTAR_GID_OFFSET, USTAR_GID_SIZE, header.gid ?? 0);
+	writeOctal(view, USTAR_SIZE_OFFSET, USTAR_SIZE_SIZE, size);
 	writeOctal(
 		view,
-		USTAR.mtime.offset,
-		USTAR.mtime.size,
+		USTAR_MTIME_OFFSET,
+		USTAR_MTIME_SIZE,
 		Math.floor((header.mtime?.getTime() ?? Date.now()) / 1000),
 	);
 	writeString(
 		view,
-		USTAR.typeflag.offset,
-		USTAR.typeflag.size,
+		USTAR_TYPEFLAG_OFFSET,
+		USTAR_TYPEFLAG_SIZE,
 		TYPEFLAG[header.type ?? "file"],
 	);
 	writeString(
 		view,
-		USTAR.linkname.offset,
-		USTAR.linkname.size,
+		USTAR_LINKNAME_OFFSET,
+		USTAR_LINKNAME_SIZE,
 		header.linkname,
 	);
 
-	writeString(view, USTAR.magic.offset, USTAR.magic.size, "ustar\0");
-	writeString(view, USTAR.version.offset, USTAR.version.size, USTAR_VERSION);
-	writeString(view, USTAR.uname.offset, USTAR.uname.size, header.uname);
-	writeString(view, USTAR.gname.offset, USTAR.gname.size, header.gname);
-	writeString(view, USTAR.prefix.offset, USTAR.prefix.size, prefix);
+	writeString(view, USTAR_MAGIC_OFFSET, USTAR_MAGIC_SIZE, "ustar\0");
+	writeString(view, USTAR_VERSION_OFFSET, USTAR_VERSION_SIZE, USTAR_VERSION);
+	writeString(view, USTAR_UNAME_OFFSET, USTAR_UNAME_SIZE, header.uname);
+	writeString(view, USTAR_GNAME_OFFSET, USTAR_GNAME_SIZE, header.gname);
+	writeString(view, USTAR_PREFIX_OFFSET, USTAR_PREFIX_SIZE, prefix);
 
 	// Calculate and write the checksum.
 	writeChecksum(view);

--- a/src/web/unpack.ts
+++ b/src/web/unpack.ts
@@ -1,5 +1,35 @@
 import { validateChecksum } from "./checksum";
-import { BLOCK_SIZE, BLOCK_SIZE_MASK, FLAGTYPE, USTAR } from "./constants";
+import {
+	BLOCK_SIZE,
+	BLOCK_SIZE_MASK,
+	FLAGTYPE,
+	USTAR_NAME_OFFSET,
+	USTAR_NAME_SIZE,
+	USTAR_MODE_OFFSET,
+	USTAR_MODE_SIZE,
+	USTAR_UID_OFFSET,
+	USTAR_UID_SIZE,
+	USTAR_GID_OFFSET,
+	USTAR_GID_SIZE,
+	USTAR_SIZE_OFFSET,
+	USTAR_SIZE_SIZE,
+	USTAR_MTIME_OFFSET,
+	USTAR_MTIME_SIZE,
+	USTAR_CHECKSUM_OFFSET,
+	USTAR_CHECKSUM_SIZE,
+	USTAR_TYPEFLAG_OFFSET,
+	USTAR_TYPEFLAG_SIZE,
+	USTAR_LINKNAME_OFFSET,
+	USTAR_LINKNAME_SIZE,
+	USTAR_MAGIC_OFFSET,
+	USTAR_MAGIC_SIZE,
+	USTAR_UNAME_OFFSET,
+	USTAR_UNAME_SIZE,
+	USTAR_GNAME_OFFSET,
+	USTAR_GNAME_SIZE,
+	USTAR_PREFIX_OFFSET,
+	USTAR_PREFIX_SIZE
+} from "./constants";
 import type { DecoderOptions, ParsedTarEntry, TarHeader } from "./types";
 import { decoder, readNumeric, readOctal, readString } from "./utils";
 
@@ -363,31 +393,31 @@ function parseUstarHeader(
 
 	const typeflag = readString(
 		block,
-		USTAR.typeflag.offset,
-		USTAR.typeflag.size,
+		USTAR_TYPEFLAG_OFFSET,
+		USTAR_TYPEFLAG_SIZE,
 	) as keyof typeof FLAGTYPE;
 
-	const magic = readString(block, USTAR.magic.offset, USTAR.magic.size);
+	const magic = readString(block, USTAR_MAGIC_OFFSET, USTAR_MAGIC_SIZE);
 	if (strict && magic !== "ustar") {
 		throw new Error(`Invalid USTAR magic: expected "ustar", got "${magic}"`);
 	}
 
 	return {
-		name: readString(block, USTAR.name.offset, USTAR.name.size),
-		mode: readOctal(block, USTAR.mode.offset, USTAR.mode.size),
-		uid: readNumeric(block, USTAR.uid.offset, USTAR.uid.size),
-		gid: readNumeric(block, USTAR.gid.offset, USTAR.gid.size),
-		size: readNumeric(block, USTAR.size.offset, USTAR.size.size),
+		name: readString(block, USTAR_NAME_OFFSET, USTAR_NAME_SIZE),
+		mode: readOctal(block, USTAR_MODE_OFFSET, USTAR_MODE_SIZE),
+		uid: readNumeric(block, USTAR_UID_OFFSET, USTAR_UID_SIZE),
+		gid: readNumeric(block, USTAR_GID_OFFSET, USTAR_GID_SIZE),
+		size: readNumeric(block, USTAR_SIZE_OFFSET, USTAR_SIZE_SIZE),
 		mtime: new Date(
-			readNumeric(block, USTAR.mtime.offset, USTAR.mtime.size) * 1000,
+			readNumeric(block, USTAR_MTIME_OFFSET, USTAR_MTIME_SIZE) * 1000,
 		),
-		checksum: readOctal(block, USTAR.checksum.offset, USTAR.checksum.size),
+		checksum: readOctal(block, USTAR_CHECKSUM_OFFSET, USTAR_CHECKSUM_SIZE),
 		type: FLAGTYPE[typeflag] || "file",
-		linkname: readString(block, USTAR.linkname.offset, USTAR.linkname.size),
+		linkname: readString(block, USTAR_LINKNAME_OFFSET, USTAR_LINKNAME_SIZE),
 		magic,
-		uname: readString(block, USTAR.uname.offset, USTAR.uname.size),
-		gname: readString(block, USTAR.gname.offset, USTAR.gname.size),
-		prefix: readString(block, USTAR.prefix.offset, USTAR.prefix.size),
+		uname: readString(block, USTAR_UNAME_OFFSET, USTAR_UNAME_SIZE),
+		gname: readString(block, USTAR_GNAME_OFFSET, USTAR_GNAME_SIZE),
+		prefix: readString(block, USTAR_PREFIX_OFFSET, USTAR_PREFIX_SIZE),
 	};
 }
 

--- a/src/web/utils.ts
+++ b/src/web/utils.ts
@@ -30,7 +30,7 @@ export function writeOctal(
 	// Format to an octal string, pad with leading zeros to size - 1.
 	// The final byte is left as 0 (NUL terminator), assuming a zero-filled view.
 	const octalString = value.toString(8).padStart(size - 1, "0");
-	writeString(view, offset, size - 1, octalString);
+	encoder.encodeInto(octalString, view.subarray(offset, offset + size - 1));
 }
 
 /**
@@ -41,14 +41,12 @@ export function readString(
 	offset: number,
 	size: number,
 ): string {
-	const slice = view.subarray(offset, offset + size);
-	const nullIndex = slice.indexOf(0);
+	// Find the first NUL byte within the specified size.
+	const end = view.indexOf(0, offset);
 
-	// Decode up to the first NUL char, or the full slice if no NUL is found.
-	const effectiveSlice =
-		nullIndex === -1 ? slice : slice.subarray(0, nullIndex);
-
-	return decoder.decode(effectiveSlice);
+	// If no NUL found, read the entire size.
+	const sliceEnd = end === -1 || end > offset + size ? offset + size : end;
+	return decoder.decode(view.subarray(offset, sliceEnd));
 }
 
 /**
@@ -59,10 +57,17 @@ export function readOctal(
 	offset: number,
 	size: number,
 ): number {
-	const octalString = readString(view, offset, size).trim();
+	let value = 0;
+	const end = offset + size;
 
-	// An empty or invalid octal string is treated as zero.
-	return octalString ? parseInt(octalString, 8) : 0;
+	for (let i = offset; i < end; i++) {
+		const charCode = view[i];
+		if (charCode === 0) break; // Stop at NUL terminator
+		if (charCode === 32) continue; // Ignore whitespace
+		value = (value << 3) + (charCode - 48); // 48 is ASCII '0'
+	}
+
+	return value;
 }
 
 /**
@@ -74,22 +79,13 @@ export function readNumeric(
 	offset: number,
 	size: number,
 ): number {
-	// POSIX base-256 encoding uses the high bit of the first byte to indicate
-	// that the field is in base-256.
 	if (view[offset] & 0x80) {
-		let result = view[offset] & 0x7f; // Handle the first byte separately, clearing the high bit.
-
-		// Start loop from the second byte.
-		for (let i = 1; i < size; i++) {
-			// (result << 8) is equivalent to (result * 256) but faster.
-			// | view[offset + i] is equivalent to + view[offset + i] for positive numbers.
+		let result = 0;
+		for (let i = 0; i < size; i++) {
 			result = (result << 8) | view[offset + i];
 		}
-
-		return result;
+		return result & ~(0x80 << ((size - 1) * 8));
 	}
-
-	// Fallback to standard octal parsing.
 	return readOctal(view, offset, size);
 }
 

--- a/tests/web/checksum.test.ts
+++ b/tests/web/checksum.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { createTarPacker, packTar, unpackTar } from "../../src/web";
-import { USTAR } from "../../src/web/constants";
+import { USTAR_CHECKSUM_OFFSET, USTAR_CHECKSUM_SIZE, USTAR_NAME_OFFSET, USTAR_SIZE_OFFSET } from "../../src/web/constants";
 import { decoder, encoder, streamToBuffer } from "../../src/web/utils";
 
 describe("checksum validation", () => {
@@ -13,7 +13,7 @@ describe("checksum validation", () => {
 		]);
 
 		// Corrupt the checksum by changing the first byte
-		buffer[USTAR.checksum.offset] = buffer[USTAR.checksum.offset] + 1;
+		buffer[USTAR_CHECKSUM_OFFSET] = buffer[USTAR_CHECKSUM_OFFSET] + 1;
 
 		await expect(unpackTar(buffer, { strict: true })).rejects.toThrow(
 			"Invalid tar header checksum",
@@ -29,8 +29,8 @@ describe("checksum validation", () => {
 		]);
 
 		// Zero out the checksum field
-		for (let i = 0; i < USTAR.checksum.size; i++) {
-			buffer[USTAR.checksum.offset + i] = 0;
+		for (let i = 0; i < USTAR_CHECKSUM_SIZE; i++) {
+			buffer[USTAR_CHECKSUM_OFFSET + i] = 0;
 		}
 
 		await expect(unpackTar(buffer, { strict: true })).rejects.toThrow(
@@ -47,7 +47,7 @@ describe("checksum validation", () => {
 		]);
 
 		// Change the first character of the filename
-		buffer[USTAR.name.offset] = buffer[USTAR.name.offset] + 1;
+		buffer[USTAR_NAME_OFFSET] = buffer[USTAR_NAME_OFFSET] + 1;
 
 		await expect(unpackTar(buffer, { strict: true })).rejects.toThrow(
 			"Invalid tar header checksum",
@@ -63,7 +63,7 @@ describe("checksum validation", () => {
 		]);
 
 		// Corrupt one byte in the size field
-		buffer[USTAR.size.offset] = buffer[USTAR.size.offset] + 1;
+		buffer[USTAR_SIZE_OFFSET] = buffer[USTAR_SIZE_OFFSET] + 1;
 
 		await expect(unpackTar(buffer, { strict: true })).rejects.toThrow(
 			"Invalid tar header checksum",
@@ -105,7 +105,7 @@ describe("checksum validation", () => {
 		const secondHeaderOffset = 512 + firstEntrySize + firstEntryPadding;
 
 		// Corrupt the checksum of the second entry
-		const secondChecksumOffset = secondHeaderOffset + USTAR.checksum.offset;
+		const secondChecksumOffset = secondHeaderOffset + USTAR_CHECKSUM_OFFSET;
 		buffer[secondChecksumOffset] = buffer[secondChecksumOffset] + 1;
 
 		// The entire extraction should fail when encountering the corrupted second entry
@@ -122,7 +122,7 @@ describe("checksum validation", () => {
 		]);
 
 		// Corrupt the checksum
-		buffer[USTAR.checksum.offset] = buffer[USTAR.checksum.offset] + 1;
+		buffer[USTAR_CHECKSUM_OFFSET] = buffer[USTAR_CHECKSUM_OFFSET] + 1;
 
 		await expect(unpackTar(buffer, { strict: true })).rejects.toThrow(
 			"Invalid tar header checksum",

--- a/tests/web/extract.test.ts
+++ b/tests/web/extract.test.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs/promises";
 import { describe, expect, it } from "vitest";
 import { createTarDecoder, packTar, unpackTar } from "../../src/web";
 import { writeChecksum } from "../../src/web/checksum";
-import { BLOCK_SIZE, TYPEFLAG, USTAR } from "../../src/web/constants";
+import { BLOCK_SIZE, TYPEFLAG, USTAR_NAME_OFFSET, USTAR_MODE_OFFSET, USTAR_SIZE_OFFSET, USTAR_CHECKSUM_OFFSET, USTAR_TYPEFLAG_OFFSET } from "../../src/web/constants";
 import type { ParsedTarEntry } from "../../src/web/types";
 import { decoder, encoder } from "../../src/web/utils";
 import {
@@ -235,15 +235,15 @@ describe("extract", () => {
 
 		// Fill in some basic header fields but leave checksum invalid
 		const nameBytes = encoder.encode("test.txt");
-		invalidHeader.set(nameBytes, USTAR.name.offset);
+		invalidHeader.set(nameBytes, USTAR_NAME_OFFSET);
 
 		// Set some other fields to make it look like a valid header
 		const modeBytes = encoder.encode("0000644 ");
-		invalidHeader.set(modeBytes, USTAR.mode.offset);
+		invalidHeader.set(modeBytes, USTAR_MODE_OFFSET);
 
 		// Invalid checksum
 		const checksumBytes = encoder.encode("000000 ");
-		invalidHeader.set(checksumBytes, USTAR.checksum.offset);
+		invalidHeader.set(checksumBytes, USTAR_CHECKSUM_OFFSET);
 
 		// @ts-expect-error ReadableStream.from is supported in tests.
 		const sourceStream = ReadableStream.from([invalidHeader]);
@@ -266,18 +266,18 @@ describe("extract", () => {
 		// Create PAX header
 		const paxHeader = new Uint8Array(BLOCK_SIZE);
 		const nameBytes = encoder.encode("PaxHeaders.0/test.txt");
-		paxHeader.set(nameBytes, USTAR.name.offset);
+		paxHeader.set(nameBytes, USTAR_NAME_OFFSET);
 
 		const modeBytes = encoder.encode("0000644 ");
-		paxHeader.set(modeBytes, USTAR.mode.offset);
+		paxHeader.set(modeBytes, USTAR_MODE_OFFSET);
 
 		const sizeBytes = encoder.encode(
 			`${paxData.length.toString(8).padStart(11, "0")} `,
 		);
-		paxHeader.set(sizeBytes, USTAR.size.offset);
+		paxHeader.set(sizeBytes, USTAR_SIZE_OFFSET);
 
 		// Set type flag for PAX header
-		paxHeader[USTAR.typeflag.offset] = encoder.encode(
+		paxHeader[USTAR_TYPEFLAG_OFFSET] = encoder.encode(
 			TYPEFLAG["pax-header"],
 		)[0];
 
@@ -490,17 +490,17 @@ describe("extract", () => {
 		// Create PAX header similar to previous test
 		const paxHeader = new Uint8Array(BLOCK_SIZE);
 		const nameBytes = encoder.encode("PaxHeaders.0/test.txt");
-		paxHeader.set(nameBytes, USTAR.name.offset);
+		paxHeader.set(nameBytes, USTAR_NAME_OFFSET);
 
 		const modeBytes = encoder.encode("0000644 ");
-		paxHeader.set(modeBytes, USTAR.mode.offset);
+		paxHeader.set(modeBytes, USTAR_MODE_OFFSET);
 
 		const sizeBytes = encoder.encode(
 			`${paxData.length.toString(8).padStart(11, "0")} `,
 		);
-		paxHeader.set(sizeBytes, USTAR.size.offset);
+		paxHeader.set(sizeBytes, USTAR_SIZE_OFFSET);
 
-		paxHeader[USTAR.typeflag.offset] = encoder.encode(
+		paxHeader[USTAR_TYPEFLAG_OFFSET] = encoder.encode(
 			TYPEFLAG["pax-header"],
 		)[0];
 
@@ -532,17 +532,17 @@ describe("extract", () => {
 		// Create PAX header
 		const paxHeader = new Uint8Array(BLOCK_SIZE);
 		const nameBytes = encoder.encode("PaxHeaders.0/test.txt");
-		paxHeader.set(nameBytes, USTAR.name.offset);
+		paxHeader.set(nameBytes, USTAR_NAME_OFFSET);
 
 		const modeBytes = encoder.encode("0000644 ");
-		paxHeader.set(modeBytes, USTAR.mode.offset);
+		paxHeader.set(modeBytes, USTAR_MODE_OFFSET);
 
 		const sizeBytes = encoder.encode(
 			`${paxData.length.toString(8).padStart(11, "0")} `,
 		);
-		paxHeader.set(sizeBytes, USTAR.size.offset);
+		paxHeader.set(sizeBytes, USTAR_SIZE_OFFSET);
 
-		paxHeader[USTAR.typeflag.offset] = encoder.encode(
+		paxHeader[USTAR_TYPEFLAG_OFFSET] = encoder.encode(
 			TYPEFLAG["pax-header"],
 		)[0];
 


### PR DESCRIPTION
The `USTAR` constant was an object which incurs object lookup costs but also minifiers do not rename properties of objects... so this actually makes a big difference to reduce the bundle size since now minifiers can inline these values safely.