### PR TITLE
perf: `replaceall` and smaller error messages

### DIFF
--- a/src/fs/archive.ts
+++ b/src/fs/archive.ts
@@ -36,7 +36,7 @@ export function packTarSources(sources: TarSource[]): Readable {
 	(async () => {
 		// TODO: Optimize with concurrency with a limit.
 		for (const source of sources) {
-			const targetPath = source.target.replace(/\\/g, "/");
+			const targetPath = source.target.replaceAll("\\", "/");
 
 			switch (source.type) {
 				case "file":
@@ -100,7 +100,7 @@ export function packTarSources(sources: TarSource[]): Readable {
 						data = encoder.encode(content);
 					} else {
 						throw new TypeError(
-							`Unsupported content type for entry "${targetPath}". Expected string, Uint8Array, ArrayBuffer, Blob, ReadableStream, or undefined.`,
+							`Unsupported content type for entry "${targetPath}".`,
 						);
 					}
 
@@ -167,7 +167,7 @@ async function addDirectoryToPacker(
 		const archiveEntryPath = path
 			.join(targetPathInArchive, dirent.name)
 			// Normalize to forward slashes for tar format.
-			.replace(/\\/g, "/");
+			.replaceAll("\\", "/");
 
 		if (dirent.isDirectory()) {
 			await addDirectoryToPacker(controller, fullSourcePath, archiveEntryPath);

--- a/src/fs/pack.ts
+++ b/src/fs/pack.ts
@@ -53,7 +53,7 @@ export function packTar(
 		if (filter?.(fullPath, stat) === false) return;
 
 		let header: TarHeader = {
-			name: currentPath.replace(/\\/g, "/"),
+			name: currentPath.replaceAll("\\", "/"),
 			mode: stat.mode,
 			mtime: stat.mtime,
 			uid: stat.uid,

--- a/src/fs/path.ts
+++ b/src/fs/path.ts
@@ -93,16 +93,14 @@ export async function validatePath(
 			validateBounds(
 				realPath,
 				root,
-				`Path traversal attempt detected: symlink "${current}" points outside the extraction directory.`,
+				`Symlink "${current}" points outside the extraction directory.`,
 			);
 
 			cache.add(current);
 			continue;
 		}
 
-		throw new Error(
-			`Path traversal attempt detected: "${current}" is not a valid directory component.`,
-		);
+		throw new Error(`"${current}" is not a valid directory component.`);
 	}
 }
 

--- a/src/fs/unpack.ts
+++ b/src/fs/unpack.ts
@@ -83,17 +83,13 @@ export function unpackTar(
 					const depth = normalizedName.split("/").length;
 
 					if (depth > maxDepth) {
-						throw new Error(
-							`Path depth of entry "${header.name}" (${depth}) exceeds the maximum allowed depth of ${maxDepth}.`,
-						);
+						throw new Error("Tar exceeds max specified depth.");
 					}
 				}
 
 				// Check for absolute paths in the entry name
 				if (path.isAbsolute(normalizedName)) {
-					throw new Error(
-						`Path traversal attempt detected for entry "${header.name}".`,
-					);
+					throw new Error(`Absolute path found in "${header.name}".`);
 				}
 
 				const outPath = path.join(resolvedDestDir, normalizedName);
@@ -101,7 +97,7 @@ export function unpackTar(
 				validateBounds(
 					outPath,
 					resolvedDestDir,
-					`Path traversal attempt detected for entry "${header.name}".`,
+					`Entry "${header.name}" points outside the extraction directory.`,
 				);
 
 				const parentDir = path.dirname(outPath);
@@ -148,7 +144,7 @@ export function unpackTar(
 							validateBounds(
 								resolvedTarget,
 								resolvedDestDir,
-								`Symlink target "${header.linkname}" points outside the extraction directory.`,
+								`Symlink "${header.linkname}" points outside the extraction directory.`,
 							);
 						}
 						await fs.symlink(header.linkname, outPath);
@@ -175,7 +171,7 @@ export function unpackTar(
 						// Check for absolute paths in hardlink target
 						if (path.isAbsolute(normalizedLinkname)) {
 							throw new Error(
-								`Hardlink target "${header.linkname}" points outside the extraction directory.`,
+								`Hardlink "${header.linkname}" points outside the extraction directory.`,
 							);
 						}
 

--- a/src/web/helpers.ts
+++ b/src/web/helpers.ts
@@ -72,7 +72,7 @@ export async function packTar(entries: TarEntry[]): Promise<Uint8Array> {
 					chunk = encoder.encode(body);
 				} else {
 					throw new TypeError(
-						`Unsupported content type for entry "${entry.header.name}". Expected string, Uint8Array, ArrayBuffer, Blob, ReadableStream, or undefined.`,
+						`Unsupported content type for entry "${entry.header.name}".`,
 					);
 				}
 

--- a/src/web/pack.ts
+++ b/src/web/pack.ts
@@ -188,7 +188,7 @@ export function createTarPacker(): {
 					totalWritten += chunk.length;
 					if (totalWritten > size) {
 						const err = new Error(
-							`Entry '${header.name}' is larger than its specified size of ${size} bytes.`,
+							`"${header.name}" exceeds given size of ${size} bytes.`,
 						);
 						streamController.error(err);
 						throw err; // Abort the write.
@@ -199,18 +199,15 @@ export function createTarPacker(): {
 
 				close() {
 					if (totalWritten !== size) {
-						const err = new Error(
-							`Size mismatch for entry '${header.name}': expected ${size} bytes but received ${totalWritten}.`,
-						);
+						const err = new Error(`Size mismatch for "${header.name}".`);
 						streamController.error(err);
 						throw err;
 					}
 
 					// Pad the entry data to fill a complete 512-byte block.
 					const paddingSize = -size & BLOCK_SIZE_MASK;
-					if (paddingSize > 0) {
+					if (paddingSize > 0)
 						streamController.enqueue(new Uint8Array(paddingSize));
-					}
 				},
 				abort(reason) {
 					streamController.error(reason);

--- a/src/web/unpack.ts
+++ b/src/web/unpack.ts
@@ -345,9 +345,7 @@ export function createTarDecoder(
 			// If we were in the middle of reading an entry, that's an error.
 			if (currentEntry) {
 				if (strict) {
-					const error = new Error(
-						`Tar archive is truncated. Expected ${currentEntry.header.size} bytes but received ${currentEntry.header.size - currentEntry.bytesLeft}.`,
-					);
+					const error = new Error("Tar archive is truncated.");
 					currentEntry.controller.error(error);
 					controller.error(error);
 				} else {
@@ -365,7 +363,7 @@ export function createTarDecoder(
 				// Check the remaining part of the first chunk (if any)
 				if (chunks.length > 0 && offset < chunks[0].length) {
 					if (chunks[0].subarray(offset).some((b) => b !== 0)) {
-						controller.error(new Error("Unexpected data at end of archive."));
+						controller.error(new Error("Invalid EOF."));
 						return;
 					}
 				}
@@ -373,7 +371,7 @@ export function createTarDecoder(
 				// Check all subsequent chunks
 				for (let i = 1; i < chunks.length; i++) {
 					if (chunks[i].some((b) => b !== 0)) {
-						controller.error(new Error("Unexpected data at end of archive."));
+						controller.error(new Error("Invalid EOF."));
 						return;
 					}
 				}
@@ -399,7 +397,7 @@ function parseUstarHeader(
 
 	const magic = readString(block, USTAR_MAGIC_OFFSET, USTAR_MAGIC_SIZE);
 	if (strict && magic !== "ustar") {
-		throw new Error(`Invalid USTAR magic: expected "ustar", got "${magic}"`);
+		throw new Error(`Invalid USTAR magic literal. Got "${magic}".`);
 	}
 
 	return {

--- a/tests/fs/security.test.ts
+++ b/tests/fs/security.test.ts
@@ -170,7 +170,7 @@ describe("security", () => {
 				const unpackStream = unpackTar(extractDir);
 
 				await expect(pipeline(maliciousTar, unpackStream)).rejects.toThrow(
-					'Path traversal attempt detected for entry "../../malicious.txt".',
+					'Entry "../../malicious.txt" points outside the extraction directory.',
 				);
 			});
 
@@ -183,7 +183,7 @@ describe("security", () => {
 				const unpackStream = unpackTar(extractDir);
 
 				await expect(pipeline(maliciousTar, unpackStream)).rejects.toThrow(
-					'Path traversal attempt detected for entry "/tmp/malicious.txt".',
+					'Absolute path found in "/tmp/malicious.txt".',
 				);
 			});
 
@@ -197,7 +197,7 @@ describe("security", () => {
 				const unpackStream = unpackTar(extractDir);
 
 				await expect(pipeline(maliciousTar, unpackStream)).rejects.toThrow(
-					'Path traversal attempt detected for entry "./safe/../../../malicious.txt".',
+					'Entry "./safe/../../../malicious.txt" points outside the extraction directory.',
 				);
 			});
 
@@ -242,7 +242,7 @@ describe("security", () => {
 				const unpackStream = unpackTar(extractDir);
 
 				await expect(pipeline(maliciousTar, unpackStream)).rejects.toThrow(
-					'Path traversal attempt detected for entry "../../malicious/".',
+					'Entry "../../malicious/" points outside the extraction directory.',
 				);
 			});
 
@@ -255,7 +255,7 @@ describe("security", () => {
 				const unpackStream = unpackTar(extractDir);
 
 				await expect(pipeline(maliciousTar, unpackStream)).rejects.toThrow(
-					'Path traversal attempt detected for entry "/tmp/malicious/".',
+					'Absolute path found in "/tmp/malicious/".',
 				);
 			});
 
@@ -301,7 +301,7 @@ describe("security", () => {
 				const unpackStream = unpackTar(extractDir);
 
 				await expect(pipeline(maliciousTar, unpackStream)).rejects.toThrow(
-					'Hardlink target "/tmp/target.txt" points outside the extraction directory.',
+					'Hardlink "/tmp/target.txt" points outside the extraction directory.',
 				);
 			});
 
@@ -340,7 +340,7 @@ describe("security", () => {
 				const unpackStream = unpackTar(extractDir);
 
 				await expect(pipeline(maliciousTar, unpackStream)).rejects.toThrow(
-					'Symlink target "../../etc/passwd" points outside the extraction directory.',
+					'Symlink "../../etc/passwd" points outside the extraction directory.',
 				);
 			},
 		);
@@ -355,7 +355,7 @@ describe("security", () => {
 				const unpackStream = unpackTar(extractDir);
 
 				await expect(pipeline(maliciousTar, unpackStream)).rejects.toThrow(
-					'Symlink target "/etc/passwd" points outside the extraction directory.',
+					'Symlink "/etc/passwd" points outside the extraction directory.',
 				);
 			},
 		);
@@ -545,7 +545,7 @@ describe("security", () => {
 				const unpackStream = unpackTar(extractDir);
 
 				await expect(pipeline(maliciousTar, unpackStream)).rejects.toThrow(
-					'Symlink target "../../etc/passwd" points outside the extraction directory.',
+					'Symlink "../../etc/passwd" points outside the extraction directory.',
 				);
 			},
 		);
@@ -563,7 +563,7 @@ describe("security", () => {
 
 				// This fixture contains a symlink 'foo' -> '../' which is a traversal attempt.
 				await expect(pipeline(readStream, unpackStream)).rejects.toThrow(
-					'Symlink target "../" points outside the extraction directory.',
+					'Symlink "../" points outside the extraction directory.',
 				);
 			},
 		);
@@ -617,7 +617,7 @@ describe("security", () => {
 			const unpackStream = unpackTar(extractDir);
 
 			await expect(pipeline(maliciousTar, unpackStream)).rejects.toThrow(
-				"Path traversal attempt detected",
+				'Entry "../../malicious-file.txt" points outside the extraction directory.',
 			);
 		});
 
@@ -680,7 +680,7 @@ describe("security", () => {
 			const unpackStream = unpackTar(extractDir);
 
 			await expect(pipeline(maliciousTar, unpackStream)).rejects.toThrow(
-				"Path traversal attempt detected",
+				'Entry "../../../malicious.txt" points outside the extraction directory.',
 			);
 
 			// Verify that safe files were created before the error
@@ -787,7 +787,7 @@ describe("security", () => {
 				const unpackStream = unpackTar(extractDir);
 
 				await expect(pipeline(maliciousTar, unpackStream)).rejects.toThrow(
-					'Symlink target "../extract-evil/malicious-file.txt" points outside the extraction directory.',
+					'Symlink "../extract-evil/malicious-file.txt" points outside the extraction directory.',
 				);
 
 				// Verify that the malicious file was NOT created
@@ -1131,7 +1131,7 @@ describe("security", () => {
 				const unpackStream = unpackTar(extractDir, { validateSymlinks: false });
 
 				await expect(pipeline(maliciousTar, unpackStream)).rejects.toThrow(
-					/Path traversal attempt detected/,
+					/Symlink .* points outside the extraction directory./,
 				);
 
 				// Verify that the malicious file was NOT created outside
@@ -1193,7 +1193,7 @@ describe("security", () => {
 
 				// Should be blocked by path validation
 				await expect(pipeline(maliciousTar, unpackStream)).rejects.toThrow(
-					/Path traversal attempt detected/,
+					/Symlink .* points outside the extraction directory./,
 				);
 
 				// Verify no file created in target directory
@@ -1375,9 +1375,7 @@ describe("security", () => {
 
 		// Should be blocked due to excessive path depth
 		await expect(pipeline(maliciousTar, unpackStream)).rejects.toThrow(
-			new RegExp(
-				`Path depth of entry .* \\(${expectedDepth}\\) exceeds the maximum allowed depth of 30`,
-			),
+			"Tar exceeds max specified depth.",
 		);
 
 		// Verify that no deeply nested directories were created
@@ -1441,7 +1439,7 @@ describe("security", () => {
 
 		// Should be blocked due to custom maxDepth of 4
 		await expect(pipeline(maliciousTar, unpackStream)).rejects.toThrow(
-			/Path depth of entry .* \(6\) exceeds the maximum allowed depth of 4/,
+			"Tar exceeds max specified depth.",
 		);
 
 		// Verify that no directories were created
@@ -1502,9 +1500,9 @@ describe("security", () => {
 		const maliciousTar = Readable.from([tarBuffer]);
 		const unpackStream = unpackTar(extractDir, { maxDepth: 15 }); // Limit to 15 levels
 
-		// Should be blocked due to excessive path depth
+		// Should be blocked due to exceeding maxDepth
 		await expect(pipeline(maliciousTar, unpackStream)).rejects.toThrow(
-			/Path depth of entry .* \(21\) exceeds the maximum allowed depth of 15/,
+			"Tar exceeds max specified depth.",
 		);
 
 		// Verify that no deeply nested directories were created

--- a/tests/fs/unpack.test.ts
+++ b/tests/fs/unpack.test.ts
@@ -217,7 +217,7 @@ describe("extract", () => {
 
 		await expect(
 			pipeline(Readable.from([tarBuffer]), unpackStream),
-		).rejects.toThrow(/Path depth.*exceeds the maximum allowed depth/);
+		).rejects.toThrow("Tar exceeds max specified depth.");
 	});
 
 	it("handles absolute paths in entries", async () => {
@@ -240,7 +240,7 @@ describe("extract", () => {
 
 		await expect(
 			pipeline(Readable.from([tarBuffer]), unpackStream),
-		).rejects.toThrow("Path traversal attempt detected");
+		).rejects.toThrow('Absolute path found in "/absolute/path.txt".');
 	});
 
 	it("handles symlink validation disabled", async () => {
@@ -266,7 +266,7 @@ describe("extract", () => {
 		const linkPath = path.join(destDir, "safe-link");
 		const linkTarget = await fs.readlink(linkPath);
 		// On Windows, symlinks may use backslashes instead of forward slashes
-		const normalizedTarget = linkTarget.replace(/\\/g, "/");
+		const normalizedTarget = linkTarget.replaceAll("\\", "/");
 		expect(normalizedTarget).toBe("../outside");
 	});
 
@@ -289,7 +289,9 @@ describe("extract", () => {
 
 		await expect(
 			pipeline(Readable.from([tarBuffer]), unpackStream),
-		).rejects.toThrow("Hardlink target");
+		).rejects.toThrow(
+			'Hardlink "/absolute/target" points outside the extraction directory.',
+		);
 	});
 
 	it("handles timestamps on symlinks", async () => {
@@ -392,7 +394,9 @@ describe("extract", () => {
 		// This should trigger the processingPromise.catch block due to path validation
 		await expect(
 			pipeline(Readable.from([tarBuffer]), unpackStream),
-		).rejects.toThrow("Symlink target");
+		).rejects.toThrow(
+			'Symlink "../../../escape-attempt" points outside the extraction directory.',
+		);
 	});
 
 	describe("edge cases", () => {

--- a/tests/web/compression.test.ts
+++ b/tests/web/compression.test.ts
@@ -455,7 +455,9 @@ describe("decompression", () => {
 			await writer.write(encoder.encode("partial")); // Only 7 bytes
 
 			// This should throw due to size mismatch
-			await expect(writer.close()).rejects.toThrow(/Size mismatch for entry 'incomplete\.txt': expected 100 bytes but received 7\./);
+			await expect(writer.close()).rejects.toThrow(
+				/Size mismatch for "incomplete\.txt"\./,
+			);
 
 			// Verify the compressed stream also fails
 			await expect(streamToBuffer(compressedStream)).rejects.toThrow();
@@ -479,7 +481,7 @@ describe("decompression", () => {
 			await writer.write(encoder.encode("hello")); // 5 bytes - OK
 			await expect(
 				writer.write(encoder.encode(" world")), // 6 more bytes - should fail
-			).rejects.toThrow(/larger than its specified size/);
+			).rejects.toThrow(/"oversized\.txt" exceeds given size of/);
 
 			// Stream should also fail
 			await expect(streamToBuffer(compressedStream)).rejects.toThrow();

--- a/tests/web/extract.test.ts
+++ b/tests/web/extract.test.ts
@@ -455,9 +455,7 @@ describe("extract", () => {
 		controller!.close();
 
 		// The flush method should detect non-zero buffer and error in strict mode
-		await expect(readPromise).rejects.toThrow(
-			"Unexpected data at end of archive",
-		);
+		await expect(readPromise).rejects.toThrow("Invalid EOF.");
 	});
 
 	it("handles unexpected data at end of archive gracefully in non-strict mode", async () => {


### PR DESCRIPTION
This adds a small optimisation to use `replaceAll` over `replace` (supported Node 15+ and we don't use this in the web package).

It also makes error messages a bit smaller for a smaller bundle size.