### PR TITLE
perf(path): simplify unicode cache

### DIFF
--- a/src/fs/path.ts
+++ b/src/fs/path.ts
@@ -1,7 +1,6 @@
 import * as path from "node:path";
 
 const unicodeCache = new Map<string, string>();
-const MAX_CACHE_SIZE = 10000;
 
 // This implements a simple LRU cache for normalized strings.
 export const normalizeUnicode = (s: string): string => {
@@ -13,15 +12,10 @@ export const normalizeUnicode = (s: string): string => {
 	result = result ?? s.normalize("NFD");
 	unicodeCache.set(s, result);
 
-	// Prune the cache if it's more than 10% over the max size.
-	const overflow = unicodeCache.size - MAX_CACHE_SIZE;
-	if (overflow > MAX_CACHE_SIZE / 10) {
-		const keys = unicodeCache.keys();
-
-		for (let i = 0; i < overflow; i++) {
-			// biome-ignore lint/style/noNonNullAssertion: This is only triggered when keys exist.
-			unicodeCache.delete(keys.next().value!);
-		}
+	// Delete the oldest entry if we exceed the max size.
+	if (unicodeCache.size > 10000) {
+		// biome-ignore lint/style/noNonNullAssertion: At minimum one entry exists here.
+		unicodeCache.delete(unicodeCache.keys().next().value!);
 	}
 
 	return result;

--- a/src/fs/win-path.ts
+++ b/src/fs/win-path.ts
@@ -1,5 +1,3 @@
-// src/fs/win-path.ts
-
 // Mapping of reserved characters to Unicode Private Use Area equivalents.
 const REPLACEMENTS: Record<string, string> = {
 	":": "\uF03A",


### PR DESCRIPTION
I originally used `node-tar`'s unicode cache implementation, but I don't really understand why we had all this extra overflow logic (you could also just hardcode things 🙈). Anyways, I'm simplifying it so it discards anything immediately.