### PR TITLE
fix(exports): use types versions for old node bundlers

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,16 @@
 		".": "./dist/web/index.js",
 		"./fs": "./dist/fs/index.js"
 	},
+	"typesVersions": {
+		"*": {
+			"fs": [
+				"dist/fs/index.d.ts"
+			],
+			"*": [
+				"dist/web/index.d.ts"
+			]
+		}
+	},
 	"devDependencies": {
 		"@biomejs/biome": "2.2.5",
 		"@types/node": "^24.7.1",


### PR DESCRIPTION
Supports old `node10` tsconfig setups. Learn more from [here](https://github.com/arethetypeswrong/arethetypeswrong.github.io/tree/main) and [here](https://github.com/andrewbranch/example-subpath-exports-ts-compat).