### PR TITLE
fix(web): do not return data on bodyless entries for pack

### DIFF
--- a/src/tar/utils.ts
+++ b/src/tar/utils.ts
@@ -1,4 +1,4 @@
-import type { TarEntryData } from "./types";
+import type { TarEntryData, TarHeader } from "./types";
 
 export const encoder = new TextEncoder();
 export const decoder = new TextDecoder();
@@ -137,3 +137,8 @@ export async function normalizeBody(body: TarEntryData): Promise<Uint8Array> {
 
 	throw new TypeError("Unsupported content type for entry body.");
 }
+
+export const isBodyless = (header: TarHeader) =>
+	header.type === "directory" ||
+	header.type === "symlink" ||
+	header.type === "link";

--- a/src/web/types.ts
+++ b/src/web/types.ts
@@ -21,8 +21,11 @@ export interface ParsedTarEntry {
 
 /**
  * Represents an extracted entry with fully buffered content.
+ *
+ * For bodyless entries (directories, symlinks, hardlinks), `data` will be `undefined`.
+ * For files (including empty files), `data` will be a `Uint8Array`.
  */
 export interface ParsedTarEntryWithData {
 	header: TarHeader;
-	data: Uint8Array;
+	data?: Uint8Array;
 }

--- a/tests/web/options.test.ts
+++ b/tests/web/options.test.ts
@@ -889,7 +889,7 @@ describe("unpack options", () => {
 			expect(entries).toHaveLength(1);
 			expect(entries[0].header.name).toBe("ROOT/LEVEL1/SUBDIR/");
 			expect(entries[0].header.type).toBe("directory");
-			expect(entries[0].data).toHaveLength(0);
+			expect(entries[0].data).toBeUndefined();
 		});
 	});
 

--- a/tests/web/repack.ts
+++ b/tests/web/repack.ts
@@ -1,0 +1,180 @@
+/** biome-ignore-all lint/style/noNonNullAssertion: Tests */
+import { describe, expect, it } from "vitest";
+import { isBodyless } from "../../src/tar/utils";
+import { packTar, unpackTar } from "../../src/web/helpers";
+import type { TarEntry } from "../../src/web/types";
+
+describe("round-trip pack/unpack", () => {
+	it("handles unpack then repack correctly", async () => {
+		// Create a test archive with various entry types
+		const originalEntries: TarEntry[] = [
+			{
+				header: { name: "file.txt", size: 11, type: "file" },
+				body: "hello world",
+			},
+			{
+				header: { name: "empty.txt", size: 0, type: "file" },
+				body: "",
+			},
+			{
+				header: { name: "dir/", type: "directory", size: 0 },
+			},
+			{
+				header: { name: "dir/nested.txt", size: 12, type: "file" },
+				body: "nested file!",
+			},
+			{
+				header: {
+					name: "link",
+					type: "symlink",
+					size: 0,
+					linkname: "file.txt",
+				},
+			},
+		];
+
+		// Pack the original entries
+		const originalArchive = await packTar(originalEntries);
+
+		// Unpack the archive
+		const unpackedEntries = await unpackTar(originalArchive);
+
+		// Verify unpacked data matches expected structure
+		expect(unpackedEntries).toHaveLength(5);
+		expect(unpackedEntries[0].header.name).toBe("file.txt");
+		expect(unpackedEntries[0].header.size).toBe(11);
+		expect(unpackedEntries[0].data).toBeDefined();
+		expect(unpackedEntries[0].data!.length).toBe(11);
+		expect(new TextDecoder().decode(unpackedEntries[0].data!)).toBe(
+			"hello world",
+		);
+
+		expect(unpackedEntries[1].header.name).toBe("empty.txt");
+		expect(unpackedEntries[1].header.size).toBe(0);
+		expect(unpackedEntries[1].data).toBeDefined();
+		expect(unpackedEntries[1].data!.length).toBe(0);
+
+		expect(unpackedEntries[2].header.name).toBe("dir/");
+		expect(unpackedEntries[2].header.type).toBe("directory");
+		expect(unpackedEntries[2].header.size).toBe(0);
+		expect(unpackedEntries[2].data).toBeUndefined();
+
+		expect(unpackedEntries[3].header.name).toBe("dir/nested.txt");
+		expect(unpackedEntries[3].header.size).toBe(12);
+		expect(unpackedEntries[3].data).toBeDefined();
+		expect(unpackedEntries[3].data!.length).toBe(12);
+		expect(new TextDecoder().decode(unpackedEntries[3].data!)).toBe(
+			"nested file!",
+		);
+
+		expect(unpackedEntries[4].header.name).toBe("link");
+		expect(unpackedEntries[4].header.type).toBe("symlink");
+		expect(unpackedEntries[4].header.size).toBe(0);
+		expect(unpackedEntries[4].data).toBeUndefined();
+
+		// Convert unpacked entries back to TarEntry format for repacking
+		const entriesForRepack: TarEntry[] = unpackedEntries.map((entry) => ({
+			header: { ...entry.header },
+			body: entry.data,
+		}));
+
+		// This should not throw an error (this was the original bug)
+		const repackedArchive = await packTar(entriesForRepack);
+
+		// Verify the repacked archive can be unpacked correctly
+		const finalEntries = await unpackTar(repackedArchive);
+
+		// Verify round-trip integrity
+		expect(finalEntries).toHaveLength(originalEntries.length);
+
+		for (let i = 0; i < finalEntries.length; i++) {
+			const final = finalEntries[i];
+			const original = originalEntries[i];
+
+			expect(final.header.name).toBe(original.header.name);
+			expect(final.header.type).toBe(original.header.type);
+			expect(final.header.size).toBe(original.header.size);
+
+			if (isBodyless(original.header)) {
+				expect(final.data).toBeUndefined();
+			} else {
+				expect(final.data).toBeDefined();
+				expect(final.data!.length).toBe(original.header.size);
+				if (original.body && typeof original.body === "string") {
+					expect(new TextDecoder().decode(final.data!)).toBe(original.body);
+				}
+			}
+		}
+	});
+
+	it("handles bodyless entries correctly during repack", async () => {
+		// Test specifically for the case where bodyless entries have empty Uint8Array bodies
+		const entries: TarEntry[] = [
+			{
+				header: { name: "dir/", type: "directory", size: 0 },
+				body: new Uint8Array(0), // Empty Uint8Array (truthy but no content)
+			},
+			{
+				header: {
+					name: "symlink",
+					type: "symlink",
+					size: 0,
+					linkname: "target",
+				},
+				body: new Uint8Array(0), // Empty Uint8Array
+			},
+		];
+
+		// This should not throw "No active tar entry" error
+		const archive = await packTar(entries);
+
+		// Verify the archive is valid
+		const unpacked = await unpackTar(archive);
+		expect(unpacked).toHaveLength(2);
+		expect(unpacked[0].header.type).toBe("directory");
+		expect(unpacked[1].header.type).toBe("symlink");
+	});
+
+	it("still validates invalid body types for non-bodyless entries", async () => {
+		// Ensure our fix doesn't break validation for actual invalid bodies
+		const invalidEntries: TarEntry[] = [
+			{
+				header: { name: "test.txt", size: 5, type: "file" },
+				// biome-ignore lint/suspicious/noExplicitAny: Intentionally invalid for testing
+				body: true as any, // Invalid body type
+			},
+		];
+
+		await expect(packTar(invalidEntries)).rejects.toThrow(
+			/Unsupported content type/,
+		);
+	});
+
+	it("handles empty files correctly", async () => {
+		// Test files with size 0 but valid body types
+		const entries: TarEntry[] = [
+			{
+				header: { name: "empty-string.txt", size: 0, type: "file" },
+				body: "", // Empty string
+			},
+			{
+				header: { name: "empty-uint8.txt", size: 0, type: "file" },
+				body: new Uint8Array(0), // Empty Uint8Array
+			},
+			{
+				header: { name: "null-body.txt", size: 0, type: "file" },
+				body: null, // Null body
+			},
+		];
+
+		const archive = await packTar(entries);
+		const unpacked = await unpackTar(archive);
+
+		expect(unpacked).toHaveLength(3);
+		unpacked.forEach((entry) => {
+			expect(entry.header.size).toBe(0);
+			expect(entry.data).toBeDefined();
+			expect(entry.data!.length).toBe(0);
+		});
+	});
+});


### PR DESCRIPTION
Closes #91.

This is a breaking change since data is now an optional field to represent undefined vs empty files.

```ts
/**
 * Represents an extracted entry with fully buffered content.
 *
 * For bodyless entries (directories, symlinks, hardlinks), `data` will be `undefined`.
 * For files (including empty files), `data` will be a `Uint8Array`.
 */
export interface ParsedTarEntryWithData {
	header: TarHeader;
	- data: Uint8Array;
	+ data?: Uint8Array;
}
```