### PR TITLE
perf(path): skip ascii normalization

### DIFF
--- a/src/fs/path.ts
+++ b/src/fs/path.ts
@@ -16,7 +16,7 @@ export const normalizeUnicode = (s: string): string => {
 		// Loop over the string and check for non-ASCII characters.
 		// This is faster than calling normalize on every string.
 		for (let i = 0; i < s.length; i++)
-			if (s.charCodeAt(i) & 0x80) {
+			if (s.charCodeAt(i) >= 128) {
 				result = s.normalize("NFD");
 				break;
 			}


### PR DESCRIPTION
Calling for `NFD` normalization is expensive, so instead we loop over the string first to validate it is all ASCII as a fast path. Since almost all paths are ASCII only, this should be a net gain.