### PR TITLE
docs(bench): use mitata and add more workloads

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -28,68 +28,251 @@ npm run bench
 
 ## Recent Results
 
-These benchmarks were run on an Apple M3 Pro and can include a lot of noise. Results should only be used to compare relative performance rather than absolute numbers.
+These benchmarks were run on an Apple M3 Pro and can include a lot of noise due to the heavy I/O bound nature of this workload. Results should only be used to compare relative performance rather than absolute numbers.
 
 ### Packing Benchmarks
 
 ```sh
---- Many Small Files (2500 x 1KB) ---
-┌─────────┬──────────────────────────────────────────────────┬─────────────────────┬───────────────────────┬────────────────────────┬────────────────────────┬─────────┐
-│ (index) │ Task name                                        │ Latency avg (ns)    │ Latency med (ns)      │ Throughput avg (ops/s) │ Throughput med (ops/s) │ Samples │
-├─────────┼──────────────────────────────────────────────────┼─────────────────────┼───────────────────────┼────────────────────────┼────────────────────────┼─────────┤
-│ 0       │ 'modern-tar: Pack Many Small Files (2500 x 1KB)' │ '62451253 ± 0.74%'  │ '61303334 ± 1556750'  │ '16 ± 0.66%'           │ '16 ± 0'               │ 241     │
-│ 1       │ 'node-tar: Pack Many Small Files (2500 x 1KB)'   │ '86689731 ± 0.45%'  │ '85902979 ± 736166'   │ '12 ± 0.42%'           │ '12 ± 0'               │ 174     │
-│ 2       │ 'tar-fs: Pack Many Small Files (2500 x 1KB)'     │ '154875495 ± 0.35%' │ '154187209 ± 1052125' │ '6 ± 0.34%'            │ '6 ± 0'                │ 97      │
-└─────────┴──────────────────────────────────────────────────┴─────────────────────┴───────────────────────┴────────────────────────┴────────────────────────┴─────────┘
+clk: ~3.95 GHz
+cpu: Apple M3 Pro
+runtime: node 24.11.0 (arm64-darwin)
 
---- Many Small Nested Files (2500 x 1KB) ---
-┌─────────┬─────────────────────────────────────────────────────────┬─────────────────────┬───────────────────────┬────────────────────────┬────────────────────────┬─────────┐
-│ (index) │ Task name                                               │ Latency avg (ns)    │ Latency med (ns)      │ Throughput avg (ops/s) │ Throughput med (ops/s) │ Samples │
-├─────────┼─────────────────────────────────────────────────────────┼─────────────────────┼───────────────────────┼────────────────────────┼────────────────────────┼─────────┤
-│ 0       │ 'modern-tar: Pack Many Small Nested Files (2500 x 1KB)' │ '62642891 ± 0.50%'  │ '61816875 ± 1234334'  │ '16 ± 0.47%'           │ '16 ± 0'               │ 240     │
-│ 1       │ 'node-tar: Pack Many Small Nested Files (2500 x 1KB)'   │ '94910419 ± 0.54%'  │ '93704708 ± 718291'   │ '11 ± 0.50%'           │ '11 ± 0'               │ 159     │
-│ 2       │ 'tar-fs: Pack Many Small Nested Files (2500 x 1KB)'     │ '161933242 ± 0.52%' │ '160315125 ± 1795917' │ '6 ± 0.51%'            │ '6 ± 0'                │ 93      │
-└─────────┴─────────────────────────────────────────────────────────┴─────────────────────┴───────────────────────┴────────────────────────┴────────────────────────┴─────────┘
+benchmark                   avg (min … max) p75 / p99    (min … top 1%)
+------------------------------------------- -------------------------------
+• Many Small Files (2500 x 1KB)
+------------------------------------------- -------------------------------
+modern-tar: Many Small Fil..  75.85 ms/iter  75.97 ms █  ▃    █
+                      (74.30 ms … 79.61 ms)  78.30 ms █▆▁█▁▁▁▆█▁▆▁▁▆▁▁▁▁▁▁▆
+                  gc(  1.10 ms …   1.84 ms)   5.81 mb (951.08 kb…  9.46 mb)
 
---- Few Large Files (5 x 20MB) ---
-┌─────────┬───────────────────────────────────────────────┬─────────────────────┬──────────────────────┬────────────────────────┬────────────────────────┬─────────┐
-│ (index) │ Task name                                     │ Latency avg (ns)    │ Latency med (ns)     │ Throughput avg (ops/s) │ Throughput med (ops/s) │ Samples │
-├─────────┼───────────────────────────────────────────────┼─────────────────────┼──────────────────────┼────────────────────────┼────────────────────────┼─────────┤
-│ 0       │ 'modern-tar: Pack Few Large Files (5 x 20MB)' │ '43597583 ± 10.47%' │ '23947917 ± 4319959' │ '33 ± 4.39%'           │ '42 ± 9'               │ 347     │
-│ 1       │ 'node-tar: Pack Few Large Files (5 x 20MB)'   │ '40396959 ± 9.14%'  │ '24635583 ± 4137395' │ '34 ± 3.87%'           │ '41 ± 8'               │ 372     │
-│ 2       │ 'tar-fs: Pack Few Large Files (5 x 20MB)'     │ '50139380 ± 9.32%'  │ '38250167 ± 2777542' │ '24 ± 3.01%'           │ '26 ± 2'               │ 300     │
-└─────────┴───────────────────────────────────────────────┴─────────────────────┴──────────────────────┴────────────────────────┴────────────────────────┴─────────┘
+node-tar: Many Small Files.. 107.29 ms/iter 106.49 ms    █
+                    (105.36 ms … 114.68 ms) 109.82 ms ▆▆▆█▁▆▁▁▁▁▁▁▁▁▁▁▁▁▁▁▆
+                  gc(  1.21 ms …   1.71 ms)  44.22 mb ( 42.62 mb… 48.09 mb)
+
+tar-fs: Many Small Files (.. 198.58 ms/iter 200.06 ms █    █ █
+                    (194.45 ms … 206.50 ms) 203.58 ms █▁▁▁████▁▁▁▁█▁▁█▁▁▁▁█
+                  gc(  1.26 ms …   1.77 ms)  15.68 mb ( 14.88 mb… 16.62 mb)
+
+                             ┌                                            ┐
+modern-tar: Many Small Fil.. ┤ 75.85 ms
+node-tar: Many Small Files.. ┤■■■■■■■■■ 107.29 ms
+tar-fs: Many Small Files (.. ┤■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 198.58 ms
+                             └                                            ┘
+
+summary
+  modern-tar: Many Small Files (2500 x 1KB)
+   1.41x faster than node-tar: Many Small Files (2500 x 1KB)
+   2.62x faster than tar-fs: Many Small Files (2500 x 1KB)
+
+• Many Small Nested Files (2500 x 1KB)
+------------------------------------------- -------------------------------
+modern-tar: Many Small Nes..  77.90 ms/iter  78.14 ms        █  █         █
+                      (77.09 ms … 78.80 ms)  78.59 ms █▁██▁█▁█▁▁█▁█▁█▁▁▁█▁█
+                  gc(  1.18 ms …   2.72 ms)   5.43 mb (  1.23 mb…  9.16 mb)
+
+node-tar: Many Small Neste.. 118.54 ms/iter 116.14 ms    █
+                    (112.85 ms … 134.20 ms) 134.08 ms ██▅█▁▁▁▁▅▁▁▁▁▁▁▁▁▁▁▁▅
+                  gc(  1.26 ms …   2.37 ms)  45.25 mb ( 42.98 mb… 47.85 mb)
+
+tar-fs: Many Small Nested .. 209.45 ms/iter 212.03 ms      █     █ █
+                    (195.33 ms … 221.31 ms) 221.21 ms █▁▁▁▁█▁█▁▁██▁█▁▁▁█▁▁█
+                  gc(  1.28 ms …   3.23 ms)  19.01 mb ( 18.08 mb… 19.92 mb)
+
+                             ┌                                            ┐
+modern-tar: Many Small Nes.. ┤ 77.90 ms
+node-tar: Many Small Neste.. ┤■■■■■■■■■■■ 118.54 ms
+tar-fs: Many Small Nested .. ┤■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 209.45 ms
+                             └                                            ┘
+
+summary
+  modern-tar: Many Small Nested Files (2500 x 1KB)
+   1.52x faster than node-tar: Many Small Nested Files (2500 x 1KB)
+   2.69x faster than tar-fs: Many Small Nested Files (2500 x 1KB)
+
+• Few Large Files (5 x 20MB)
+------------------------------------------- -------------------------------
+modern-tar: Few Large File..  25.10 ms/iter  22.53 ms  █
+                      (19.55 ms … 83.54 ms)  51.60 ms ██▃▃▃▁▂▃▁▁▁▂▁▁▁▁▂▁▁▁▂
+                  gc(  1.08 ms …   2.37 ms) 152.79 kb (  4.20 kb…467.24 kb)
+
+node-tar: Few Large Files ..  22.45 ms/iter  20.43 ms █
+                      (19.61 ms … 59.11 ms)  53.12 ms █▃▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁
+                  gc(  1.21 ms …   2.29 ms)  73.07 kb ( 28.29 kb…159.42 kb)
+
+tar-fs: Few Large Files (5..  44.13 ms/iter  45.68 ms █  █ █ █ █    █
+                      (41.25 ms … 47.68 ms)  47.66 ms ████████▁███▁██▁███▁█
+                  gc(  1.15 ms …   1.75 ms) 194.86 kb ( 38.34 kb…553.30 kb)
+
+                             ┌                                            ┐
+modern-tar: Few Large File.. ┤■■■■ 25.10 ms
+node-tar: Few Large Files .. ┤ 22.45 ms
+tar-fs: Few Large Files (5.. ┤■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 44.13 ms
+                             └                                            ┘
+
+summary
+  node-tar: Few Large Files (5 x 20MB)
+   1.12x faster than modern-tar: Few Large Files (5 x 20MB)
+   1.97x faster than tar-fs: Few Large Files (5 x 20MB)
+
+• Huge Files (2 x 1GB)
+------------------------------------------- -------------------------------
+modern-tar: Huge Files (2 .. 827.32 ms/iter 724.95 ms █
+                       (701.90 ms … 1.64 s)    1.15 s █▅▁▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▃
+                  gc(  1.83 ms …   6.85 ms)   2.31 mb ( 60.71 kb…  4.44 mb)
+
+node-tar: Huge Files (2 x .. 859.22 ms/iter 826.17 ms    █
+                       (619.76 ms … 1.59 s)    1.17 s ▄▁▁█▇▁▁▁▄▁▁▁▁▁▁▁▁▁▁▄▄
+                  gc(  1.19 ms …   6.24 ms)  65.29 kb ( 42.09 kb… 77.27 kb)
+
+tar-fs: Huge Files (2 x 1GB)    1.11 s/iter    1.71 s █
+                       (762.14 ms … 1.97 s)    1.74 s █▆▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▄▆
+                  gc(  1.27 ms …   7.70 ms) 250.64 kb (117.95 kb…535.49 kb)
+
+                             ┌                                            ┐
+modern-tar: Huge Files (2 .. ┤ 827.32 ms
+node-tar: Huge Files (2 x .. ┤■■■■ 859.22 ms
+tar-fs: Huge Files (2 x 1GB) ┤■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 1.11 s
+                             └                                            ┘
+
+summary
+  modern-tar: Huge Files (2 x 1GB)
+   1.04x faster than node-tar: Huge Files (2 x 1GB)
+   1.35x faster than tar-fs: Huge Files (2 x 1GB)
 ```
 
 ### Unpacking Benchmarks
 
 ```sh
---- Many Small Files (2500 x 1KB) ---
-┌─────────┬────────────────────────────────────────────────────┬─────────────────────┬────────────────────────┬────────────────────────┬────────────────────────┬─────────┐
-│ (index) │ Task name                                          │ Latency avg (ns)    │ Latency med (ns)       │ Throughput avg (ops/s) │ Throughput med (ops/s) │ Samples │
-├─────────┼────────────────────────────────────────────────────┼─────────────────────┼────────────────────────┼────────────────────────┼────────────────────────┼─────────┤
-│ 0       │ 'modern-tar: Unpack Many Small Files (2500 x 1KB)' │ '135197180 ± 1.09%' │ '134176333 ± 4318458'  │ '7 ± 1.04%'            │ '7 ± 0'                │ 111     │
-│ 1       │ 'node-tar: Unpack Many Small Files (2500 x 1KB)'   │ '194336629 ± 1.10%' │ '192998833 ± 7543895'  │ '5 ± 1.09%'            │ '5 ± 0'                │ 78      │
-│ 2       │ 'tar-fs: Unpack Many Small Files (2500 x 1KB)'     │ '524907015 ± 2.02%' │ '536602646 ± 18800583' │ '2 ± 2.09%'            │ '2 ± 0'                │ 30      │
-└─────────┴────────────────────────────────────────────────────┴─────────────────────┴────────────────────────┴────────────────────────┴────────────────────────┴─────────┘
+clk: ~3.95 GHz
+cpu: Apple M3 Pro
+runtime: node 24.11.0 (arm64-darwin)
 
---- Many Small Nested Files (2500 x 1KB) ---
-┌─────────┬───────────────────────────────────────────────────────────┬─────────────────────┬────────────────────────┬────────────────────────┬────────────────────────┬─────────┐
-│ (index) │ Task name                                                 │ Latency avg (ns)    │ Latency med (ns)       │ Throughput avg (ops/s) │ Throughput med (ops/s) │ Samples │
-├─────────┼───────────────────────────────────────────────────────────┼─────────────────────┼────────────────────────┼────────────────────────┼────────────────────────┼─────────┤
-│ 0       │ 'modern-tar: Unpack Many Small Nested Files (2500 x 1KB)' │ '166566736 ± 0.76%' │ '165969875 ± 4058125'  │ '6 ± 0.75%'            │ '6 ± 0'                │ 91      │
-│ 1       │ 'node-tar: Unpack Many Small Nested Files (2500 x 1KB)'   │ '364342735 ± 1.64%' │ '359822521 ± 12994563' │ '3 ± 1.60%'            │ '3 ± 0'                │ 42      │
-│ 2       │ 'tar-fs: Unpack Many Small Nested Files (2500 x 1KB)'     │ '567124578 ± 1.46%' │ '566608812 ± 14051833' │ '2 ± 1.47%'            │ '2 ± 0'                │ 30      │
-└─────────┴───────────────────────────────────────────────────────────┴─────────────────────┴────────────────────────┴────────────────────────┴────────────────────────┴─────────┘
+benchmark                   avg (min … max) p75 / p99    (min … top 1%)
+------------------------------------------- -------------------------------
+• Many Small Files (2500 x 1KB)
+------------------------------------------- -------------------------------
+modern-tar: Many Small Fil.. 225.72 ms/iter 232.58 ms       █        █    █
+                    (213.89 ms … 234.45 ms) 234.02 ms █▁▁▁█▁██▁█▁▁▁▁▁█▁▁▁██
+                  gc(  1.50 ms …   3.12 ms)  36.27 mb ( 35.13 mb… 38.37 mb)
 
---- Few Large Files (5 x 20MB) ---
-┌─────────┬─────────────────────────────────────────────────┬────────────────────┬──────────────────────┬────────────────────────┬────────────────────────┬─────────┐
-│ (index) │ Task name                                       │ Latency avg (ns)   │ Latency med (ns)     │ Throughput avg (ops/s) │ Throughput med (ops/s) │ Samples │
-├─────────┼─────────────────────────────────────────────────┼────────────────────┼──────────────────────┼────────────────────────┼────────────────────────┼─────────┤
-│ 0       │ 'modern-tar: Unpack Few Large Files (5 x 20MB)' │ '35877987 ± 4.11%' │ '29541167 ± 2477751' │ '31 ± 2.45%'           │ '34 ± 3'               │ 419     │
-│ 1       │ 'node-tar: Unpack Few Large Files (5 x 20MB)'   │ '39709622 ± 4.50%' │ '34362438 ± 904791'  │ '27 ± 1.97%'           │ '29 ± 1'               │ 378     │
-│ 2       │ 'tar-fs: Unpack Few Large Files (5 x 20MB)'     │ '66414937 ± 7.42%' │ '59902979 ± 8376146' │ '16 ± 2.78%'           │ '17 ± 2'               │ 226     │
-└─────────┴─────────────────────────────────────────────────┴────────────────────┴──────────────────────┴────────────────────────┴────────────────────────┴─────────┘
+node-tar: Many Small Files.. 275.24 ms/iter 273.55 ms          █
+                    (256.49 ms … 319.05 ms) 294.85 ms ▆▁▁▆▆▆▁▆▆█▁▁▆▁▁▁▁▁▁▁▆
+                  gc(  1.58 ms …   2.56 ms)  42.14 mb ( 41.49 mb… 43.23 mb)
+
+tar-fs: Many Small Files (.. 568.48 ms/iter 561.26 ms        ██
+                    (517.05 ms … 693.21 ms) 617.22 ms █▁█▁▁█████▁▁▁▁▁▁█▁▁▁█
+                  gc(  1.52 ms …   1.86 ms)   6.14 mb (  4.94 mb…  7.35 mb)
+
+                             ┌                                            ┐
+modern-tar: Many Small Fil.. ┤ 225.72 ms
+node-tar: Many Small Files.. ┤■■■■■ 275.24 ms
+tar-fs: Many Small Files (.. ┤■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 568.48 ms
+                             └                                            ┘
+
+summary
+  modern-tar: Many Small Files (2500 x 1KB)
+   1.22x faster than node-tar: Many Small Files (2500 x 1KB)
+   2.52x faster than tar-fs: Many Small Files (2500 x 1KB)
+
+• Many Small Nested Files (2500 x 1KB)
+------------------------------------------- -------------------------------
+modern-tar: Many Small Nes.. 246.18 ms/iter 251.81 ms       █         █  █
+                    (232.73 ms … 254.93 ms) 253.22 ms █▁▁▁▁▁█▁▁█▁█▁▁█▁█▁▁██
+                  gc(  1.68 ms …   4.03 ms)  42.13 mb ( 41.88 mb… 42.77 mb)
+
+node-tar: Many Small Neste.. 413.24 ms/iter 417.91 ms                 █  ▃
+                    (391.77 ms … 440.56 ms) 419.72 ms ▆▁▁▁▁▁▁▁▆▁▆▆▁▁▆▁█▁▁█▆
+                  gc(  1.62 ms …   2.36 ms)  28.82 mb ( 28.49 mb… 29.44 mb)
+
+tar-fs: Many Small Nested .. 634.07 ms/iter 651.90 ms         █           █
+                    (579.61 ms … 681.47 ms) 664.41 ms █▁▁▁█▁▁██▁▁▁▁▁████▁▁█
+                  gc(  1.55 ms …   2.18 ms)  23.83 mb ( 22.91 mb… 24.34 mb)
+
+                             ┌                                            ┐
+modern-tar: Many Small Nes.. ┤ 246.18 ms
+node-tar: Many Small Neste.. ┤■■■■■■■■■■■■■■■ 413.24 ms
+tar-fs: Many Small Nested .. ┤■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 634.07 ms
+                             └                                            ┘
+
+summary
+  modern-tar: Many Small Nested Files (2500 x 1KB)
+   1.68x faster than node-tar: Many Small Nested Files (2500 x 1KB)
+   2.58x faster than tar-fs: Many Small Nested Files (2500 x 1KB)
+
+• Few Large Files (5 x 20MB)
+------------------------------------------- -------------------------------
+modern-tar: Few Large File..  23.73 ms/iter  25.19 ms  █▆▆   █
+                      (20.92 ms … 35.09 ms)  33.68 ms ▆███▆▁▃█▃▄▁▃▁▁▁▁▁▁▁▁▃
+                  gc(  1.34 ms …   3.17 ms) 406.68 kb ( 32.52 kb…  1.49 mb)
+
+node-tar: Few Large Files ..  26.17 ms/iter  26.44 ms   ▂  █
+                      (23.95 ms … 33.47 ms)  33.26 ms ▄▆█▇▇█▂▄▂▂▂▁▂▁▁▁▁▁▁▁▂
+                  gc(  1.39 ms …   2.58 ms) 226.45 kb (  8.72 kb…  1.42 mb)
+
+tar-fs: Few Large Files (5..  27.77 ms/iter  28.62 ms  █
+                      (25.55 ms … 35.87 ms)  35.59 ms ▇█▇██▃▄▄▆▁▁▃▁▁▁▁▃▁▁▁▃
+                  gc(  1.32 ms …   2.73 ms) 467.79 kb ( 57.35 kb…  1.24 mb)
+
+                             ┌                                            ┐
+modern-tar: Few Large File.. ┤ 23.73 ms
+node-tar: Few Large Files .. ┤■■■■■■■■■■■■■■■■■■■■■ 26.17 ms
+tar-fs: Few Large Files (5.. ┤■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 27.77 ms
+                             └                                            ┘
+
+summary
+  modern-tar: Few Large Files (5 x 20MB)
+   1.1x faster than node-tar: Few Large Files (5 x 20MB)
+   1.17x faster than tar-fs: Few Large Files (5 x 20MB)
+
+• Huge Files (2 x 1GB)
+------------------------------------------- -------------------------------
+modern-tar: Huge Files (2 .. 704.90 ms/iter 707.82 ms           █
+                    (696.53 ms … 712.80 ms) 711.71 ms ▆▁▆▁▁▁▆▆▁▁█▁▁▁▆▆▆▁▁▁▆
+                  gc(  1.74 ms …   2.70 ms) 420.57 kb ( 37.62 kb…  1.30 mb)
+
+node-tar: Huge Files (2 x ..    1.15 s/iter    1.70 s █▄
+                       (708.76 ms … 1.92 s)    1.77 s ██▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▅▁█▅
+                  gc(  2.22 ms …   8.28 ms) 157.81 kb ( 46.95 kb…267.91 kb)
+
+tar-fs: Huge Files (2 x 1GB) 991.30 ms/iter 823.52 ms ▂█
+                       (711.56 ms … 1.84 s)    1.66 s ██▄▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▇
+                  gc(  2.05 ms …   8.38 ms) 188.25 kb (136.40 kb…280.16 kb)
+
+                             ┌                                            ┐
+modern-tar: Huge Files (2 .. ┤ 704.90 ms
+node-tar: Huge Files (2 x .. ┤■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 1.15 s
+tar-fs: Huge Files (2 x 1GB) ┤■■■■■■■■■■■■■■■■■■■■■■ 991.30 ms
+                             └                                            ┘
+
+summary
+  modern-tar: Huge Files (2 x 1GB)
+   1.41x faster than tar-fs: Huge Files (2 x 1GB)
+   1.64x faster than node-tar: Huge Files (2 x 1GB)
+
+• Linked Small Files (500 packages, symlinks + hardlinks)
+------------------------------------------- -------------------------------
+modern-tar: Linked Small F..    1.14 s/iter    1.17 s                █
+                          (1.05 s … 1.22 s)    1.21 s ▆▁▁▁▆▆▆▁▆▆▁▆▁▁▁█▁▁▁▁▆
+                  gc(  1.69 ms …   2.38 ms)  39.77 mb ( 38.78 mb… 40.89 mb)
+
+node-tar: Linked Small Fil..    1.50 s/iter    1.55 s   █ █
+                          (1.41 s … 1.63 s)    1.59 s █▁█▁█▁█▁█▁▁▁▁█▁█▁█▁▁█
+                  gc(  1.64 ms …   2.96 ms)  13.42 mb (193.63 kb… 64.65 mb)
+
+tar-fs: Linked Small Files..    1.90 s/iter    1.93 s            █
+                          (1.77 s … 2.03 s)    2.03 s █▁██▁█▁▁██▁█▁█▁▁▁▁▁██
+                  gc(  1.72 ms …   2.93 ms)  26.34 mb ( 25.28 mb… 27.61 mb)
+
+                             ┌                                            ┐
+modern-tar: Linked Small F.. ┤ 1.14 s
+node-tar: Linked Small Fil.. ┤■■■■■■■■■■■■■■■■ 1.50 s
+tar-fs: Linked Small Files.. ┤■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 1.90 s
+                             └                                            ┘
+
+summary
+  modern-tar: Linked Small Files (500 packages, symlinks + hardlinks)
+   1.32x faster than node-tar: Linked Small Files (500 packages, symlinks + hardlinks)
+   1.67x faster than tar-fs: Linked Small Files (500 packages, symlinks + hardlinks)
 ```
 
-For large files `modern-tar` and `node-tar` are practically very similar in performance since at this point the bottleneck is I/O. However, for many small files, `modern-tar` shows much better results than other libraries.
+For large files `modern-tar` and `node-tar` are very similar in performance since at this point the bottleneck is I/O. However, for many small files, `modern-tar` shows significantly better results than other libraries.

--- a/benchmarks/fixtures/generate.ts
+++ b/benchmarks/fixtures/generate.ts
@@ -8,52 +8,65 @@ const FIXTURES_DIR = path.resolve(__dirname, "..", "data");
 const SMALL_FILES_DIR = path.join(FIXTURES_DIR, "small-files");
 const LARGE_FILES_DIR = path.join(FIXTURES_DIR, "large-files");
 const NESTED_FILES_DIR = path.join(FIXTURES_DIR, "nested-files");
+const GIGANTIC_FILES_DIR = path.join(FIXTURES_DIR, "gigantic-files");
+const LINK_TREE_DIR = path.join(FIXTURES_DIR, "link-tree");
 
 const SMALL_FILE_COUNT = 2500;
 const SMALL_FILE_SIZE = 1024; // 1 KB
 const LARGE_FILE_COUNT = 5;
 const LARGE_FILE_SIZE = 20 * 1024 * 1024; // 20 MB
 const NESTED_FILE_COUNT = 2500;
-const NESTED_FILE_SIZE = 1024; // 1 KB (same as small files for fair comparison)
+const NESTED_FILE_SIZE = 1024; // 1 KB
+const GIGANTIC_FILE_COUNT = 2;
+const GIGANTIC_FILE_SIZE = 1024 * 1024 * 1024; // 1 GB
+const LINK_TREE_PACKAGE_COUNT = 500;
+const LINK_TREE_FILE_SIZE = 1024; // 1 KB
 
 export async function generateFixtures() {
 	console.log("Generating fixtures...");
 	await fs.rm(FIXTURES_DIR, { recursive: true, force: true });
 
-	// Many small files (flat structure)
+	await createSmallFiles();
+	await createLargeFiles();
+	await createNestedFilesFixture();
+	await createGiganticFiles();
+
+	// Link-heavy workspace (symlinks + hardlinks).
+	await createLinkTreeFixture();
+
+	console.log("Fixtures generated successfully.");
+}
+
+async function createSmallFiles() {
 	await fs.mkdir(SMALL_FILES_DIR, { recursive: true });
-	const smallFileContent = Buffer.alloc(SMALL_FILE_SIZE, "a");
-	const smallFilePromises: Promise<void>[] = [];
+	const content = Buffer.alloc(SMALL_FILE_SIZE, "a");
+	const writes: Promise<void>[] = [];
+
 	for (let i = 0; i < SMALL_FILE_COUNT; i++) {
-		smallFilePromises.push(
-			fs.writeFile(
-				path.join(SMALL_FILES_DIR, `file-${i}.txt`),
-				smallFileContent,
-			),
-		);
+		const filePath = path.join(SMALL_FILES_DIR, `file-${i}.txt`);
+		writes.push(fs.writeFile(filePath, content));
 	}
-	await Promise.all(smallFilePromises);
 
-	// Few large files (flat structure)
+	await Promise.all(writes);
+}
+
+async function createLargeFiles() {
 	await fs.mkdir(LARGE_FILES_DIR, { recursive: true });
-	const largeFileContent = Buffer.alloc(LARGE_FILE_SIZE, "b");
-	const largeFilePromises: Promise<void>[] = [];
-	for (let i = 0; i < LARGE_FILE_COUNT; i++) {
-		largeFilePromises.push(
-			fs.writeFile(
-				path.join(LARGE_FILES_DIR, `large-file-${i}.bin`),
-				largeFileContent,
-			),
-		);
-	}
-	await Promise.all(largeFilePromises);
+	const content = Buffer.alloc(LARGE_FILE_SIZE, "b");
+	const writes: Promise<void>[] = [];
 
-	// Nested directory structure for path normalization testing
+	for (let i = 0; i < LARGE_FILE_COUNT; i++) {
+		const filePath = path.join(LARGE_FILES_DIR, `large-file-${i}.bin`);
+		writes.push(fs.writeFile(filePath, content));
+	}
+
+	await Promise.all(writes);
+}
+
+async function createNestedFilesFixture() {
 	await fs.mkdir(NESTED_FILES_DIR, { recursive: true });
 	const nestedFileContent = Buffer.alloc(NESTED_FILE_SIZE, "c");
-	const nestedFilePromises: Promise<void>[] = [];
 
-	// Create a variety of nested structures to test path normalization
 	const structures = [
 		// Simple nesting levels
 		"level1",
@@ -126,24 +139,22 @@ export async function generateFixtures() {
 		"mixed-style_naming/camelCase_mix",
 	];
 
-	// Create directories and distribute files across them
 	for (const structure of structures) {
-		const fullPath = path.join(NESTED_FILES_DIR, structure);
-		await fs.mkdir(fullPath, { recursive: true });
+		await fs.mkdir(path.join(NESTED_FILES_DIR, structure), { recursive: true });
 	}
 
-	// Distribute files across the nested structure
+	const distributedWrites: Promise<void>[] = [];
 	for (let i = 0; i < NESTED_FILE_COUNT; i++) {
 		const structure = structures[i % structures.length];
-		const fileName = `nested-file-${i}.dat`;
-		const filePath = path.join(NESTED_FILES_DIR, structure, fileName);
-
-		nestedFilePromises.push(
-			fs.writeFile(filePath, nestedFileContent)
+		const filePath = path.join(
+			NESTED_FILES_DIR,
+			structure,
+			`nested-file-${i}.dat`,
 		);
+		distributedWrites.push(fs.writeFile(filePath, nestedFileContent));
 	}
+	await Promise.all(distributedWrites);
 
-	// Add some files with challenging names for path normalization
 	const challengingNames = [
 		"file with spaces.txt",
 		"file-with-very-long-name-that-might-cause-issues-with-tar-format-limits-and-path-normalization.txt",
@@ -154,16 +165,146 @@ export async function generateFixtures() {
 		"normal.tar.gz.bz2.txt", // Extension confusion
 	];
 
-	for (const challengingName of challengingNames) {
-		nestedFilePromises.push(
+	await Promise.all(
+		challengingNames.map((name) =>
 			fs.writeFile(
-				path.join(NESTED_FILES_DIR, "level1", "level2", challengingName),
-				nestedFileContent
-			)
-		);
+				path.join(NESTED_FILES_DIR, "level1", "level2", name),
+				nestedFileContent,
+			),
+		),
+	);
+}
+
+async function createGiganticFiles() {
+	await fs.mkdir(GIGANTIC_FILES_DIR, { recursive: true });
+
+	for (let i = 0; i < GIGANTIC_FILE_COUNT; i++) {
+		const filePath = path.join(GIGANTIC_FILES_DIR, `gigantic-file-${i}.bin`);
+		await createLargeFile(filePath, GIGANTIC_FILE_SIZE);
 	}
+}
 
-	await Promise.all(nestedFilePromises);
+async function createLargeFile(
+	filePath: string,
+	sizeBytes: number,
+) {
+	const handle = await fs.open(filePath, "w");
+	const chunkSize = 16 * 1024 * 1024; // 16 MB
+	const chunk = Buffer.alloc(chunkSize, "L");
 
-	console.log("Fixtures generated successfully.");
+	try {
+		let bytesLeft = sizeBytes;
+		while (bytesLeft > 0) {
+			const currentChunk =
+				bytesLeft >= chunk.length ? chunk : chunk.subarray(0, bytesLeft);
+			await handle.write(currentChunk);
+			bytesLeft -= currentChunk.length;
+		}
+	} finally {
+		await handle.close();
+	}
+}
+
+async function createLinkTreeFixture() {
+	await fs.mkdir(LINK_TREE_DIR, { recursive: true });
+
+	const workspaceRoot = path.join(LINK_TREE_DIR, "workspace");
+	const workspaceNodeModules = path.join(workspaceRoot, "node_modules");
+	const workspaceBinDir = path.join(workspaceNodeModules, ".bin");
+	const virtualStoreDir = path.join(workspaceNodeModules, ".virtual-store");
+	const storeDir = path.join(LINK_TREE_DIR, "virtual-store");
+
+	await Promise.all([
+		fs.mkdir(workspaceNodeModules, { recursive: true }),
+		fs.mkdir(workspaceBinDir, { recursive: true }),
+		fs.mkdir(virtualStoreDir, { recursive: true }),
+		fs.mkdir(storeDir, { recursive: true }),
+	]);
+
+	const makeSymlink = async (
+		targetPath: string,
+		linkPath: string,
+		type: "file" | "junction" = "file",
+	) => {
+		const linkDir = path.dirname(linkPath);
+		await fs.mkdir(linkDir, { recursive: true });
+		const relativeTarget = path.relative(linkDir, targetPath) || ".";
+		await fs.symlink(relativeTarget, linkPath, type);
+	};
+
+	const packages = Array.from({ length: LINK_TREE_PACKAGE_COUNT }, (_, index) => ({
+		name: `linkpkg-${index.toString().padStart(4, "0")}`,
+		version: `1.0.${index}`,
+		description: "virtual-store link tree test package",
+	}));
+
+	for (let i = 0; i < packages.length; i++) {
+		const pkg = packages[i];
+		const pkgKey = `${pkg.name}@${pkg.version}`;
+		const storePackageDir = path.join(storeDir, pkgKey);
+
+		await fs.mkdir(storePackageDir, { recursive: true });
+		await fs.mkdir(path.join(storePackageDir, "lib"), { recursive: true });
+		await fs.mkdir(path.join(storePackageDir, "bin"), { recursive: true });
+		await fs.mkdir(path.join(storePackageDir, "data"), { recursive: true });
+
+		const payload = Buffer.alloc(
+			LINK_TREE_FILE_SIZE,
+			String.fromCharCode(97 + (i % 26)),
+		);
+
+		await fs.writeFile(
+			path.join(storePackageDir, "package.json"),
+			JSON.stringify(
+				{
+					name: pkg.name,
+					version: pkg.version,
+					description: pkg.description,
+					main: "index.js",
+					bin: {
+						[pkg.name]: "./bin/cli.js",
+					},
+					files: ["lib", "bin", "index.js", "data"],
+				},
+				null,
+				2,
+			),
+		);
+		await fs.writeFile(
+			path.join(storePackageDir, "index.js"),
+			`exports.name = "${pkg.name}";\nexports.version = "${pkg.version}";\n`,
+		);
+		await fs.writeFile(
+			path.join(storePackageDir, "lib", "index.js"),
+			`module.exports = function greet() {\n  return "${pkg.name}::${pkg.version}";\n};\n`,
+		);
+		await fs.writeFile(
+			path.join(storePackageDir, "README.md"),
+			`# ${pkg.name}\n\n${pkg.description} (${i})\n`,
+		);
+		await fs.writeFile(
+			path.join(storePackageDir, "data", `payload-${i}.bin`),
+			payload,
+		);
+		await fs.writeFile(
+			path.join(storePackageDir, "bin", "cli.js"),
+			`#!/usr/bin/env node\nconsole.log("${pkg.name} cli");\n`,
+			{ mode: 0o755 },
+		);
+
+		const virtualStorePackageDir = path.join(
+			virtualStoreDir,
+			pkgKey,
+			"node_modules",
+			pkg.name,
+		);
+		await makeSymlink(storePackageDir, virtualStorePackageDir, "junction");
+
+		const workspacePackageLink = path.join(workspaceNodeModules, pkg.name);
+		await makeSymlink(virtualStorePackageDir, workspacePackageLink, "junction");
+
+		const binTarget = path.join(virtualStorePackageDir, "bin", "cli.js");
+		const binLink = path.join(workspaceBinDir, pkg.name);
+		await makeSymlink(binTarget, binLink, "file");
+	}
 }

--- a/benchmarks/pack.bench.ts
+++ b/benchmarks/pack.bench.ts
@@ -3,11 +3,10 @@ import * as fsp from "node:fs/promises";
 import * as path from "node:path";
 import { pipeline } from "node:stream/promises";
 import { fileURLToPath } from "node:url";
+import { barplot, bench, group, run, summary } from "mitata";
 import { packTar } from "modern-tar/fs";
 import * as tar from "tar";
 import * as tarfs from "tar-fs";
-
-import { Bench } from "tinybench";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -17,6 +16,7 @@ const TARBALLS_DIR = path.join(TMP_DIR, "tarballs");
 const SMALL_FILES_DIR = path.resolve(__dirname, "data/small-files");
 const LARGE_FILES_DIR = path.resolve(__dirname, "data/large-files");
 const NESTED_FILES_DIR = path.resolve(__dirname, "data/nested-files");
+const GIGANTIC_FILES_DIR = path.resolve(__dirname, "data/gigantic-files");
 
 async function setup() {
 	await fsp.rm(TMP_DIR, { recursive: true, force: true });
@@ -34,6 +34,17 @@ function createUniqueTarballPath(): string {
 	);
 }
 
+async function withTemporaryTarball(
+	fn: (tarballPath: string) => Promise<void>,
+): Promise<void> {
+	const tarballPath = createUniqueTarballPath();
+	try {
+		await fn(tarballPath);
+	} finally {
+		await fsp.rm(tarballPath, { force: true });
+	}
+}
+
 export async function runPackingBenchmarks() {
 	await setup();
 	console.log("\nPacking benchmarks...");
@@ -42,72 +53,45 @@ export async function runPackingBenchmarks() {
 		{ name: "Many Small Files (2500 x 1KB)", dir: SMALL_FILES_DIR },
 		{ name: "Many Small Nested Files (2500 x 1KB)", dir: NESTED_FILES_DIR },
 		{ name: "Few Large Files (5 x 20MB)", dir: LARGE_FILES_DIR },
+		{ name: "Huge Files (2 x 1GB)", dir: GIGANTIC_FILES_DIR },
 	]) {
-		const bench = new Bench({
-			time: 15000,
-			iterations: 30,
-			warmupTime: 5000,
-			warmupIterations: 10,
+		group(testCase.name, () => {
+			const registerBench = (
+				label: string,
+				fn: (tarballPath: string) => Promise<void>,
+			) =>
+				bench(label, async () => {
+					await withTemporaryTarball(async (tarballPath) => {
+						await fn(tarballPath);
+					});
+				}).gc("inner");
+
+			barplot(() => {
+				summary(() => {
+					registerBench(`modern-tar: ${testCase.name}`, async (tarballPath) => {
+						const writeStream = fs.createWriteStream(tarballPath);
+						await pipeline(packTar(testCase.dir), writeStream);
+					});
+
+					registerBench(`node-tar: ${testCase.name}`, async (tarballPath) => {
+						await tar.c(
+							{
+								file: tarballPath,
+								C: path.dirname(testCase.dir),
+							},
+							[path.basename(testCase.dir)],
+						);
+					});
+
+					registerBench(`tar-fs: ${testCase.name}`, async (tarballPath) => {
+						const writeStream = fs.createWriteStream(tarballPath);
+						await pipeline(tarfs.pack(testCase.dir), writeStream);
+					});
+				});
+			});
 		});
-
-		let uniqueTarballPath: string;
-
-		bench
-			.add(
-				`modern-tar: Pack ${testCase.name}`,
-				async () => {
-					const writeStream = fs.createWriteStream(uniqueTarballPath);
-					await pipeline(packTar(testCase.dir), writeStream);
-				},
-				{
-					beforeEach() {
-						uniqueTarballPath = createUniqueTarballPath();
-					},
-					async afterEach() {
-						await fsp.rm(uniqueTarballPath, { force: true });
-					},
-				},
-			)
-			.add(
-				`node-tar: Pack ${testCase.name}`,
-				async () => {
-					await tar.c(
-						{
-							file: uniqueTarballPath,
-							C: path.dirname(testCase.dir),
-						},
-						[path.basename(testCase.dir)],
-					);
-				},
-				{
-					beforeEach() {
-						uniqueTarballPath = createUniqueTarballPath();
-					},
-					async afterEach() {
-						await fsp.rm(uniqueTarballPath, { force: true });
-					},
-				},
-			)
-			.add(
-				`tar-fs: Pack ${testCase.name}`,
-				async () => {
-					const writeStream = fs.createWriteStream(uniqueTarballPath);
-					await pipeline(tarfs.pack(testCase.dir), writeStream);
-				},
-				{
-					beforeEach() {
-						uniqueTarballPath = createUniqueTarballPath();
-					},
-					async afterEach() {
-						await fsp.rm(uniqueTarballPath, { force: true });
-					},
-				},
-			);
-
-		await bench.run();
-		console.log(`\n--- ${testCase.name} ---`);
-		console.table(bench.table());
 	}
 
+	await run({ format: { mitata: { name: "fixed" } } });
 	await teardown();
 }

--- a/benchmarks/package-lock.json
+++ b/benchmarks/package-lock.json
@@ -8,10 +8,10 @@
 			"name": "modern-tar-benchmarks",
 			"version": "0.0.0",
 			"dependencies": {
+				"mitata": "^1.0.34",
 				"modern-tar": "file:..",
 				"tar": "^7.5.1",
-				"tar-fs": "^3.1.1",
-				"tinybench": "^5.0.1"
+				"tar-fs": "^3.1.1"
 			},
 			"devDependencies": {
 				"@types/node": "^24.5.2",
@@ -21,15 +21,15 @@
 			}
 		},
 		"..": {
-			"version": "0.4.1",
+			"version": "0.7.1",
 			"license": "MIT",
 			"devDependencies": {
-				"@biomejs/biome": "2.2.5",
-				"@types/node": "^24.6.2",
-				"@vitest/coverage-v8": "^3.2.4",
-				"tsdown": "^0.15.6",
+				"@biomejs/biome": "2.3.5",
+				"@types/node": "^24.10.1",
+				"@vitest/coverage-v8": "^4.0.8",
+				"tsdown": "^0.16.3",
 				"typescript": "^5.9.3",
-				"vitest": "^3.2.4"
+				"vitest": "^4.0.8"
 			},
 			"engines": {
 				"node": ">=18.0.0"
@@ -259,6 +259,12 @@
 				"node": ">=16 || 14 >=14.17"
 			}
 		},
+		"node_modules/mitata": {
+			"version": "1.0.34",
+			"resolved": "https://registry.npmjs.org/mitata/-/mitata-1.0.34.tgz",
+			"integrity": "sha512-Mc3zrtNBKIMeHSCQ0XqRLo1vbdIx1wvFV9c8NJAiyho6AjNfMY8bVhbS12bwciUdd1t4rj8099CH3N3NFahaUA==",
+			"license": "MIT"
+		},
 		"node_modules/modern-tar": {
 			"resolved": "..",
 			"link": true
@@ -350,15 +356,6 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"b4a": "^1.6.4"
-			}
-		},
-		"node_modules/tinybench": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-5.0.1.tgz",
-			"integrity": "sha512-aNVgWQZY4veCZLQJRftDA1X9OoLUIjDWNfC90nledkX7Lx205IpSEFYnsu4slyofoPGpJ+NIQj+BNSt4U5edMg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=20.0.0"
 			}
 		},
 		"node_modules/typescript": {

--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -4,17 +4,17 @@
 	"version": "0.0.0",
 	"type": "module",
 	"scripts": {
-		"bench": "node --experimental-strip-types run.bench.ts",
-		"bench:pack": "node --experimental-strip-types run.pack.ts",
-		"bench:unpack": "node --experimental-strip-types run.unpack.ts",
-		"deopt": "dexnode run.unpack.ts -- --experimental-strip-types ",
+		"bench": "node --expose-gc --experimental-strip-types run.bench.ts",
+		"bench:pack": "node --expose-gc --experimental-strip-types run.pack.ts",
+		"bench:unpack": "node --expose-gc --experimental-strip-types run.unpack.ts",
+		"deopt": "dexnode run.unpack.ts -- --expose-gc --experimental-strip-types ",
 		"fixtures": "node --experimental-strip-types fixtures/generate.ts"
 	},
 	"dependencies": {
+		"mitata": "^1.0.34",
 		"modern-tar": "file:..",
 		"tar": "^7.5.1",
-		"tar-fs": "^3.1.1",
-		"tinybench": "^5.0.1"
+		"tar-fs": "^3.1.1"
 	},
 	"devDependencies": {
 		"@types/node": "^24.5.2",

--- a/benchmarks/unpack.bench.ts
+++ b/benchmarks/unpack.bench.ts
@@ -3,30 +3,58 @@ import * as fsp from "node:fs/promises";
 import * as path from "node:path";
 import { pipeline } from "node:stream/promises";
 import { fileURLToPath } from "node:url";
+import { barplot, bench, group, run, summary } from "mitata";
 import { packTar, unpackTar } from "modern-tar/fs";
 import * as tar from "tar";
 import * as tarFs from "tar-fs";
-
-import { Bench } from "tinybench";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const TMP_DIR = path.resolve(__dirname, "..", "tmp");
 const TARBALLS_DIR = path.join(TMP_DIR, "tarballs");
+const READ_CHUNK_SIZE = 256 * 1024; // 256KB buffer
 
 const SMALL_FILES_DIR = path.resolve(__dirname, "data/small-files");
 const LARGE_FILES_DIR = path.resolve(__dirname, "data/large-files");
 const NESTED_FILES_DIR = path.resolve(__dirname, "data/nested-files");
+const GIGANTIC_FILES_DIR = path.resolve(__dirname, "data/gigantic-files");
+const LINK_TREE_DIR = path.resolve(__dirname, "data/link-tree");
+
+const FIXTURE_SOURCES = [
+	{ name: "small-files", dir: SMALL_FILES_DIR },
+	{ name: "large-files", dir: LARGE_FILES_DIR },
+	{ name: "nested-files", dir: NESTED_FILES_DIR },
+	{ name: "gigantic-files", dir: GIGANTIC_FILES_DIR },
+	{ name: "link-tree", dir: LINK_TREE_DIR },
+] as const;
+
+type BenchmarkCase = {
+	name: string;
+	file: string;
+};
+
+const BENCHMARK_CASES: BenchmarkCase[] = [
+	{ name: "Many Small Files (2500 x 1KB)", file: "small-files.tar" },
+	{
+		name: "Many Small Nested Files (2500 x 1KB)",
+		file: "nested-files.tar",
+	},
+	{ name: "Few Large Files (5 x 20MB)", file: "large-files.tar" },
+	{
+		name: "Huge Files (2 x 1GB)",
+		file: "gigantic-files.tar",
+	},
+	{
+		name: "Linked Small Files (500 packages, symlinks + hardlinks)",
+		file: "link-tree.tar",
+	},
+];
 
 async function setup() {
 	await fsp.rm(TMP_DIR, { recursive: true, force: true });
 	await fsp.mkdir(TARBALLS_DIR, { recursive: true });
 
-	for (const testCase of [
-		{ name: "small-files", dir: SMALL_FILES_DIR },
-		{ name: "large-files", dir: LARGE_FILES_DIR },
-		{ name: "nested-files", dir: NESTED_FILES_DIR },
-	]) {
+	for (const testCase of FIXTURE_SOURCES) {
 		const tarballPath = path.join(TARBALLS_DIR, `${testCase.name}.tar`);
 		const writeStream = fs.createWriteStream(tarballPath);
 		await pipeline(packTar(testCase.dir), writeStream);
@@ -42,80 +70,66 @@ async function createUniqueExtractDir(): Promise<string> {
 	return extractDir;
 }
 
+async function withTemporaryExtractDir(
+	fn: (extractDir: string) => Promise<void>,
+): Promise<void> {
+	const extractDir = await createUniqueExtractDir();
+	try {
+		await fn(extractDir);
+	} finally {
+		await fsp.rm(extractDir, { recursive: true, force: true });
+	}
+}
+
 export async function runUnpackingBenchmarks() {
 	await setup();
 	console.log("\nUnpacking benchmarks...");
 
-	for (const testCase of [
-		{ name: "Many Small Files (2500 x 1KB)", file: "small-files.tar" },
-		{ name: "Many Small Nested Files (2500 x 1KB)", file: "nested-files.tar" },
-		{ name: "Few Large Files (5 x 20MB)", file: "large-files.tar" },
-	]) {
+	for (const testCase of BENCHMARK_CASES) {
 		const tarballPath = path.join(TARBALLS_DIR, testCase.file);
-		const bench = new Bench({
-			time: 15000,
-			iterations: 30,
-			warmupTime: 5000,
-			warmupIterations: 10,
-		});
+		const datasetLabel = `${testCase.name}`;
 
-		let extractDir: string;
-
-		bench
-			.add(
-				`modern-tar: Unpack ${testCase.name}`,
-				async () => {
-					const readStream = fs.createReadStream(tarballPath, {
-						// Recommended tuning params for large files.
-						highWaterMark: 256 * 1024, // 256 KB
+		group(datasetLabel, () => {
+			const registerBench = (
+				label: string,
+				fn: (extractDir: string) => Promise<void>,
+			) =>
+				bench(label, async () => {
+					await withTemporaryExtractDir(async (extractDir) => {
+						await fn(extractDir);
 					});
-					const unpackStream = unpackTar(extractDir);
-					await pipeline(readStream, unpackStream);
-				},
-				{
-					async beforeEach() {
-						extractDir = await createUniqueExtractDir();
-					},
-					async afterEach() {
-						await fsp.rm(extractDir, { recursive: true, force: true });
-					},
-				},
-			)
-			.add(
-				`node-tar: Unpack ${testCase.name}`,
-				async () => {
-					await tar.x({ f: tarballPath, C: extractDir });
-				},
-				{
-					async beforeEach() {
-						extractDir = await createUniqueExtractDir();
-					},
-					async afterEach() {
-						await fsp.rm(extractDir, { recursive: true, force: true });
-					},
-				},
-			)
-			.add(
-				`tar-fs: Unpack ${testCase.name}`,
-				async () => {
-					const readStream = fs.createReadStream(tarballPath);
-					const extractStream = tarFs.extract(extractDir);
-					await pipeline(readStream, extractStream);
-				},
-				{
-					async beforeEach() {
-						extractDir = await createUniqueExtractDir();
-					},
-					async afterEach() {
-						await fsp.rm(extractDir, { recursive: true, force: true });
-					},
-				},
-			);
+				}).gc("inner");
 
-		await bench.run();
-		console.log(`\n--- ${testCase.name} ---`);
-		console.table(bench.table());
+			barplot(() => {
+				summary(() => {
+					registerBench(`modern-tar: ${testCase.name}`, async (extractDir) => {
+						const readStream = fs.createReadStream(tarballPath, {
+							highWaterMark: READ_CHUNK_SIZE,
+						});
+						const unpackStream = unpackTar(extractDir);
+						await pipeline(readStream, unpackStream);
+					});
+
+					registerBench(`node-tar: ${testCase.name}`, async (extractDir) => {
+						const readStream = fs.createReadStream(tarballPath, {
+							highWaterMark: READ_CHUNK_SIZE,
+						});
+						const extractStream = tar.x({ cwd: extractDir });
+						await pipeline(readStream, extractStream);
+					});
+
+					registerBench(`tar-fs: ${testCase.name}`, async (extractDir) => {
+						const readStream = fs.createReadStream(tarballPath, {
+							highWaterMark: READ_CHUNK_SIZE,
+						});
+						const extractStream = tarFs.extract(extractDir);
+						await pipeline(readStream, extractStream);
+					});
+				});
+			});
+		});
 	}
 
+	await run({ format: { mitata: { name: "fixed" } } });
 	await fsp.rm(TMP_DIR, { recursive: true, force: true });
 }


### PR DESCRIPTION
Switches to `mitata` for better visualisation of performance differences, and adds a new HUGE file benchmark and a heavily symlinked variant as often implementations have to handle them completely differently.