### PR TITLE
perf(chunk): reallocate with fresh array with empty queue

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -143,7 +143,7 @@ summary
 ### Unpacking Benchmarks
 
 ```sh
-clk: ~3.95 GHz
+clk: ~3.94 GHz
 cpu: Apple M3 Pro
 runtime: node 24.11.0 (arm64-darwin)
 
@@ -151,128 +151,128 @@ benchmark                   avg (min … max) p75 / p99    (min … top 1%)
 ------------------------------------------- -------------------------------
 • Many Small Files (2500 x 1KB)
 ------------------------------------------- -------------------------------
-modern-tar: Many Small Fil.. 225.72 ms/iter 232.58 ms       █        █    █
-                    (213.89 ms … 234.45 ms) 234.02 ms █▁▁▁█▁██▁█▁▁▁▁▁█▁▁▁██
-                  gc(  1.50 ms …   3.12 ms)  36.27 mb ( 35.13 mb… 38.37 mb)
+modern-tar: Many Small Fil.. 224.94 ms/iter 231.64 ms     █  █
+                    (205.25 ms … 262.98 ms) 251.75 ms ██▁██▁▁██▁▁██▁▁▁▁▁▁▁█
+                  gc(  1.26 ms …   2.14 ms)  35.80 mb ( 34.91 mb… 37.48 mb)
 
-node-tar: Many Small Files.. 275.24 ms/iter 273.55 ms          █
-                    (256.49 ms … 319.05 ms) 294.85 ms ▆▁▁▆▆▆▁▆▆█▁▁▆▁▁▁▁▁▁▁▆
-                  gc(  1.58 ms …   2.56 ms)  42.14 mb ( 41.49 mb… 43.23 mb)
+node-tar: Many Small Files.. 309.20 ms/iter 323.41 ms           █         ▃
+                    (274.66 ms … 376.22 ms) 327.51 ms ▆▁▁▆▁▆▁▆▁▁█▁▁▁▆▁▁▁▆▁█
+                  gc(  1.40 ms …   3.07 ms)  42.10 mb ( 41.43 mb… 43.26 mb)
 
-tar-fs: Many Small Files (.. 568.48 ms/iter 561.26 ms        ██
-                    (517.05 ms … 693.21 ms) 617.22 ms █▁█▁▁█████▁▁▁▁▁▁█▁▁▁█
-                  gc(  1.52 ms …   1.86 ms)   6.14 mb (  4.94 mb…  7.35 mb)
+tar-fs: Many Small Files (.. 576.95 ms/iter 603.21 ms        █            █
+                    (531.99 ms … 617.60 ms) 609.23 ms █▁▁██▁▁█▁▁██▁▁▁▁▁██▁█
+                  gc(  1.36 ms …   2.00 ms)   6.14 mb (  4.91 mb…  7.34 mb)
 
                              ┌                                            ┐
-modern-tar: Many Small Fil.. ┤ 225.72 ms
-node-tar: Many Small Files.. ┤■■■■■ 275.24 ms
-tar-fs: Many Small Files (.. ┤■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 568.48 ms
+modern-tar: Many Small Fil.. ┤ 224.94 ms
+node-tar: Many Small Files.. ┤■■■■■■■■ 309.20 ms
+tar-fs: Many Small Files (.. ┤■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 576.95 ms
                              └                                            ┘
 
 summary
   modern-tar: Many Small Files (2500 x 1KB)
-   1.22x faster than node-tar: Many Small Files (2500 x 1KB)
-   2.52x faster than tar-fs: Many Small Files (2500 x 1KB)
+   1.37x faster than node-tar: Many Small Files (2500 x 1KB)
+   2.56x faster than tar-fs: Many Small Files (2500 x 1KB)
 
 • Many Small Nested Files (2500 x 1KB)
 ------------------------------------------- -------------------------------
-modern-tar: Many Small Nes.. 246.18 ms/iter 251.81 ms       █         █  █
-                    (232.73 ms … 254.93 ms) 253.22 ms █▁▁▁▁▁█▁▁█▁█▁▁█▁█▁▁██
-                  gc(  1.68 ms …   4.03 ms)  42.13 mb ( 41.88 mb… 42.77 mb)
+modern-tar: Many Small Nes.. 246.66 ms/iter 247.60 ms █     █      █
+                    (238.85 ms … 262.44 ms) 252.07 ms █▁▁▁▁▁█▁▁█▁███▁▁█▁▁▁█
+                  gc(  1.43 ms …   4.44 ms)  41.81 mb ( 41.76 mb… 41.89 mb)
 
-node-tar: Many Small Neste.. 413.24 ms/iter 417.91 ms                 █  ▃
-                    (391.77 ms … 440.56 ms) 419.72 ms ▆▁▁▁▁▁▁▁▆▁▆▆▁▁▆▁█▁▁█▆
-                  gc(  1.62 ms …   2.36 ms)  28.82 mb ( 28.49 mb… 29.44 mb)
+node-tar: Many Small Neste.. 455.29 ms/iter 449.31 ms      ██ █           █
+                    (423.73 ms … 553.38 ms) 484.76 ms ███▁▁██▁█▁▁▁▁▁▁▁▁▁▁▁█
+                  gc(  1.48 ms …   2.13 ms)  28.82 mb ( 28.50 mb… 29.48 mb)
 
-tar-fs: Many Small Nested .. 634.07 ms/iter 651.90 ms         █           █
-                    (579.61 ms … 681.47 ms) 664.41 ms █▁▁▁█▁▁██▁▁▁▁▁████▁▁█
-                  gc(  1.55 ms …   2.18 ms)  23.83 mb ( 22.91 mb… 24.34 mb)
+tar-fs: Many Small Nested .. 672.93 ms/iter 710.12 ms                 █
+                    (594.31 ms … 764.43 ms) 740.80 ms ██▁█▁▁██▁▁▁██▁█▁█▁▁▁█
+                  gc(  1.46 ms …   2.30 ms)  23.83 mb ( 22.83 mb… 24.35 mb)
 
                              ┌                                            ┐
-modern-tar: Many Small Nes.. ┤ 246.18 ms
-node-tar: Many Small Neste.. ┤■■■■■■■■■■■■■■■ 413.24 ms
-tar-fs: Many Small Nested .. ┤■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 634.07 ms
+modern-tar: Many Small Nes.. ┤ 246.66 ms
+node-tar: Many Small Neste.. ┤■■■■■■■■■■■■■■■■■ 455.29 ms
+tar-fs: Many Small Nested .. ┤■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 672.93 ms
                              └                                            ┘
 
 summary
   modern-tar: Many Small Nested Files (2500 x 1KB)
-   1.68x faster than node-tar: Many Small Nested Files (2500 x 1KB)
-   2.58x faster than tar-fs: Many Small Nested Files (2500 x 1KB)
+   1.85x faster than node-tar: Many Small Nested Files (2500 x 1KB)
+   2.73x faster than tar-fs: Many Small Nested Files (2500 x 1KB)
 
 • Few Large Files (5 x 20MB)
 ------------------------------------------- -------------------------------
-modern-tar: Few Large File..  23.73 ms/iter  25.19 ms  █▆▆   █
-                      (20.92 ms … 35.09 ms)  33.68 ms ▆███▆▁▃█▃▄▁▃▁▁▁▁▁▁▁▁▃
-                  gc(  1.34 ms …   3.17 ms) 406.68 kb ( 32.52 kb…  1.49 mb)
+modern-tar: Few Large File..  24.48 ms/iter  25.17 ms  ▆█▆ ▆█▆
+                      (19.64 ms … 55.91 ms)  36.48 ms ████████▆▄▁▁▄▁▁▁▁▄▁▁▄
+                  gc(  1.15 ms …   2.26 ms) 418.67 kb ( 34.72 kb…  1.28 mb)
 
-node-tar: Few Large Files ..  26.17 ms/iter  26.44 ms   ▂  █
-                      (23.95 ms … 33.47 ms)  33.26 ms ▄▆█▇▇█▂▄▂▂▂▁▂▁▁▁▁▁▁▁▂
-                  gc(  1.39 ms …   2.58 ms) 226.45 kb (  8.72 kb…  1.42 mb)
+node-tar: Few Large Files ..  33.18 ms/iter  32.55 ms   █  ▂
+                     (24.77 ms … 120.19 ms)  41.96 ms ▅▃█▃▅█▃▅▅▃▁▃▅▃▃▁▁▁▃▁▃
+                  gc(  1.17 ms …   2.35 ms) 336.17 kb ( 16.00 kb…967.75 kb)
 
-tar-fs: Few Large Files (5..  27.77 ms/iter  28.62 ms  █
-                      (25.55 ms … 35.87 ms)  35.59 ms ▇█▇██▃▄▄▆▁▁▃▁▁▁▁▃▁▁▁▃
-                  gc(  1.32 ms …   2.73 ms) 467.79 kb ( 57.35 kb…  1.24 mb)
+tar-fs: Few Large Files (5..  37.47 ms/iter  37.21 ms ▄▄█ ▄
+                     (26.39 ms … 128.21 ms)  54.22 ms ███▅█▁▁▅▅▅▁▁▅▅▁▁▁▁▁▁▅
+                  gc(  1.18 ms …   2.66 ms) 390.72 kb ( 53.30 kb…  0.99 mb)
 
                              ┌                                            ┐
-modern-tar: Few Large File.. ┤ 23.73 ms
-node-tar: Few Large Files .. ┤■■■■■■■■■■■■■■■■■■■■■ 26.17 ms
-tar-fs: Few Large Files (5.. ┤■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 27.77 ms
+modern-tar: Few Large File.. ┤ 24.48 ms
+node-tar: Few Large Files .. ┤■■■■■■■■■■■■■■■■■■■■■■■ 33.18 ms
+tar-fs: Few Large Files (5.. ┤■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 37.47 ms
                              └                                            ┘
 
 summary
   modern-tar: Few Large Files (5 x 20MB)
-   1.1x faster than node-tar: Few Large Files (5 x 20MB)
-   1.17x faster than tar-fs: Few Large Files (5 x 20MB)
+   1.36x faster than node-tar: Few Large Files (5 x 20MB)
+   1.53x faster than tar-fs: Few Large Files (5 x 20MB)
 
 • Huge Files (2 x 1GB)
 ------------------------------------------- -------------------------------
-modern-tar: Huge Files (2 .. 704.90 ms/iter 707.82 ms           █
-                    (696.53 ms … 712.80 ms) 711.71 ms ▆▁▆▁▁▁▆▆▁▁█▁▁▁▆▆▆▁▁▁▆
-                  gc(  1.74 ms …   2.70 ms) 420.57 kb ( 37.62 kb…  1.30 mb)
+modern-tar: Huge Files (2 .. 747.24 ms/iter 752.26 ms ███  ██  ████ █     █
+                    (718.49 ms … 806.17 ms) 776.98 ms ███▁▁██▁▁████▁█▁▁▁▁▁█
+                  gc(  2.00 ms …   3.42 ms) 587.62 kb ( 58.54 kb…  1.50 mb)
 
-node-tar: Huge Files (2 x ..    1.15 s/iter    1.70 s █▄
-                       (708.76 ms … 1.92 s)    1.77 s ██▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▅▁█▅
-                  gc(  2.22 ms …   8.28 ms) 157.81 kb ( 46.95 kb…267.91 kb)
+node-tar: Huge Files (2 x .. 784.60 ms/iter 786.11 ms              █
+                    (752.83 ms … 871.87 ms) 794.01 ms █▁▁▁▁▁██▁▁██▁█▁███▁▁█
+                  gc(  1.63 ms …   4.82 ms) 189.04 kb (118.23 kb…668.97 kb)
 
-tar-fs: Huge Files (2 x 1GB) 991.30 ms/iter 823.52 ms ▂█
-                       (711.56 ms … 1.84 s)    1.66 s ██▄▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▇
-                  gc(  2.05 ms …   8.38 ms) 188.25 kb (136.40 kb…280.16 kb)
+tar-fs: Huge Files (2 x 1GB) 777.01 ms/iter 783.46 ms          █  ▃       ▃
+                    (738.88 ms … 871.27 ms) 787.81 ms ▆▁▁▁▁▁▁▁▁█▆▁█▁▁▆▁▁▆▁█
+                  gc(  1.91 ms …   5.78 ms) 187.93 kb (145.30 kb…307.59 kb)
 
                              ┌                                            ┐
-modern-tar: Huge Files (2 .. ┤ 704.90 ms
-node-tar: Huge Files (2 x .. ┤■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 1.15 s
-tar-fs: Huge Files (2 x 1GB) ┤■■■■■■■■■■■■■■■■■■■■■■ 991.30 ms
+modern-tar: Huge Files (2 .. ┤ 747.24 ms
+node-tar: Huge Files (2 x .. ┤■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 784.60 ms
+tar-fs: Huge Files (2 x 1GB) ┤■■■■■■■■■■■■■■■■■■■■■■■■■■■ 777.01 ms
                              └                                            ┘
 
 summary
   modern-tar: Huge Files (2 x 1GB)
-   1.41x faster than tar-fs: Huge Files (2 x 1GB)
-   1.64x faster than node-tar: Huge Files (2 x 1GB)
+   1.04x faster than tar-fs: Huge Files (2 x 1GB)
+   1.05x faster than node-tar: Huge Files (2 x 1GB)
 
 • Linked Small Files (500 packages, symlinks + hardlinks)
 ------------------------------------------- -------------------------------
-modern-tar: Linked Small F..    1.14 s/iter    1.17 s                █
-                          (1.05 s … 1.22 s)    1.21 s ▆▁▁▁▆▆▆▁▆▆▁▆▁▁▁█▁▁▁▁▆
-                  gc(  1.69 ms …   2.38 ms)  39.77 mb ( 38.78 mb… 40.89 mb)
+modern-tar: Linked Small F..    1.35 s/iter    1.42 s   █                 █
+                          (1.25 s … 1.44 s)    1.43 s █▁█▁▁██▁▁█▁▁█▁▁▁▁█▁██
+                  gc(  1.49 ms …   2.87 ms)  37.18 mb ( 37.02 mb… 37.94 mb)
 
-node-tar: Linked Small Fil..    1.50 s/iter    1.55 s   █ █
-                          (1.41 s … 1.63 s)    1.59 s █▁█▁█▁█▁█▁▁▁▁█▁█▁█▁▁█
-                  gc(  1.64 ms …   2.96 ms)  13.42 mb (193.63 kb… 64.65 mb)
+node-tar: Linked Small Fil..    1.83 s/iter    1.90 s     █        █
+                          (1.63 s … 2.03 s)    1.93 s █▁▁▁█▁▁▁▁▁▁▁██▁█▁████
+                  gc(  1.67 ms …   2.32 ms)  32.89 mb (744.70 kb… 64.73 mb)
 
-tar-fs: Linked Small Files..    1.90 s/iter    1.93 s            █
-                          (1.77 s … 2.03 s)    2.03 s █▁██▁█▁▁██▁█▁█▁▁▁▁▁██
-                  gc(  1.72 ms …   2.93 ms)  26.34 mb ( 25.28 mb… 27.61 mb)
+tar-fs: Linked Small Files..    2.13 s/iter    2.18 s            █
+                          (1.94 s … 2.30 s)    2.28 s ▆▁▁▁▆▁▆▁▁▁▆█▆▁▁▆▁▁▁▆▆
+                  gc(  1.66 ms …   3.18 ms)  26.19 mb ( 25.16 mb… 27.36 mb)
 
                              ┌                                            ┐
-modern-tar: Linked Small F.. ┤ 1.14 s
-node-tar: Linked Small Fil.. ┤■■■■■■■■■■■■■■■■ 1.50 s
-tar-fs: Linked Small Files.. ┤■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 1.90 s
+modern-tar: Linked Small F.. ┤ 1.35 s
+node-tar: Linked Small Fil.. ┤■■■■■■■■■■■■■■■■■■■■■ 1.83 s
+tar-fs: Linked Small Files.. ┤■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 2.13 s
                              └                                            ┘
 
 summary
   modern-tar: Linked Small Files (500 packages, symlinks + hardlinks)
-   1.32x faster than node-tar: Linked Small Files (500 packages, symlinks + hardlinks)
-   1.67x faster than tar-fs: Linked Small Files (500 packages, symlinks + hardlinks)
+   1.36x faster than node-tar: Linked Small Files (500 packages, symlinks + hardlinks)
+   1.58x faster than tar-fs: Linked Small Files (500 packages, symlinks + hardlinks)
 ```
 
 For large files `modern-tar` and `node-tar` are very similar in performance since at this point the bottleneck is I/O. However, for many small files, `modern-tar` shows significantly better results than other libraries.

--- a/src/tar/chunk-queue.ts
+++ b/src/tar/chunk-queue.ts
@@ -9,6 +9,8 @@ interface ChunkQueue {
 	pull(bytes: number, callback: (chunk: Uint8Array) => boolean): number;
 }
 
+const INITIAL_CAPACITY = 256;
+
 /**
  * Creates a circular buffer for streaming TAR archive parsing.
  *
@@ -19,7 +21,7 @@ interface ChunkQueue {
 export function createChunkQueue(): ChunkQueue {
 	// - 8 bytes chunk reference
 	// = 256 * 8 = 2kb initial memory overhead
-	let chunks = new Array<Uint8Array>(256);
+	let chunks = new Array<Uint8Array>(INITIAL_CAPACITY);
 	// Each slot stores the remaining portion of a chunk, so offsets are implicit.
 	let capacityMask = chunks.length - 1; // For bitwise wrapping (length is power of 2).
 
@@ -39,6 +41,14 @@ export function createChunkQueue(): ChunkQueue {
 		}
 
 		totalAvailable -= count;
+
+		// Forcefully resetting lets the GC reclaim memory for large queues.
+		if (totalAvailable === 0 && chunks.length > INITIAL_CAPACITY) {
+			chunks = new Array<Uint8Array>(INITIAL_CAPACITY);
+			capacityMask = INITIAL_CAPACITY - 1;
+			head = 0;
+			tail = 0;
+		}
 	};
 
 	/**


### PR DESCRIPTION
This can help with mixed workloads with one large file and many small files by reset the chunk queue size when there is no work to be done.