### PR TITLE
Fix parsing of archives with directories that have type=FILE name=.../

### DIFF
--- a/src/tar/header.ts
+++ b/src/tar/header.ts
@@ -151,6 +151,9 @@ export function parseUstarHeader(
 		linkname: readString(block, USTAR_LINKNAME_OFFSET, USTAR_LINKNAME_SIZE),
 	};
 
+	if(header.name.endsWith("/") && header.type === FILE)
+		header.type = DIRECTORY;
+
 	const magic = readString(block, USTAR_MAGIC_OFFSET, USTAR_MAGIC_SIZE);
 
 	// Both GNU and USTAR formats have uname and gname.


### PR DESCRIPTION
<https://ftp.okass.net/pub/mirror/minnie.tuhs.org/Distributions/Research/Dennis_v5/v5root.tar.gz> has directory entries with typeflag of "" and names that end in /

GNU tar and libarchive understand this

This patch mirrors libarchive

Ref: https://github.com/libarchive/libarchive/blob/8d1c9b95f1fbc68f3882ef859d6caf7b701fde7c/libarchive/archive_read_support_format_tar.c#L583