### PR TITLE
Fix parsing of archives with type=link entries with size!=0

### DIFF
--- a/src/tar/header.ts
+++ b/src/tar/header.ts
@@ -153,6 +153,9 @@ export function parseUstarHeader(
 
 	const magic = readString(block, USTAR_MAGIC_OFFSET, USTAR_MAGIC_SIZE);
 
+	if(header.type === LINK)
+		header.size = 0;
+
 	// Both GNU and USTAR formats have uname and gname.
 	if (magic.trim() === "ustar") {
 		header.uname = readString(block, USTAR_UNAME_OFFSET, USTAR_UNAME_SIZE);


### PR DESCRIPTION
<http://ftp.okass.net/pub/mirror/minnie.tuhs.org/Distributions/Research/Henry_Spencer_v7/v7.tar.gz>
has
```
usr/sys/h/pk.p^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@   664 ^@     2 ^@     2 ^@       3511  2147133241  12405^@ 1usr/include/sys/pk.p
```
which modern-tar reads as
```
-rw-rw-r--                2/2         289    1979-01-10 20:20:43Z usr/sys/h/reg.h
-rw-rw-r--                2/2         636    1979-01-10 20:20:44Z usr/sys/h/seg.h
hrw-rw-r--                2/2        1865    1979-05-13 22:37:21Z usr/sys/h/pk.p link to usr/include/sys/pk.p
-r---wsr-T 15590316/122483667 10394646407 +018967-01-10 21:06:36Z *iget();
struct inode *owner();
struct inode *maknode();
struct inode *namei();
struct buf *alloc();
```
but bsdtar -tvf:
```
-rw-rw-r--  0 2      2         289 Jan 10  1979 usr/sys/h/reg.h
-rw-rw-r--  0 2      2         636 Jan 10  1979 usr/sys/h/seg.h
-rw-rw-r--  0 2      2           0 May 14  1979 usr/sys/h/pk.p link to usr/include/sys/pk.p
-rw-rw-r--  0 2      2        2138 Jan 10  1979 usr/sys/h/systm.h
-rw-rw-r--  0 2      2         742 Jan 10  1979 usr/sys/h/text.h
```
and GNU tar -tvaf:
```
-rw-rw-r-- 2/2             289 1979-01-10 21:20 usr/sys/h/reg.h
-rw-rw-r-- 2/2             636 1979-01-10 21:20 usr/sys/h/seg.h
hrw-rw-r-- 2/2               0 1979-05-14 00:37 usr/sys/h/pk.p link to usr/include/sys/pk.p
-rw-rw-r-- 2/2            2138 1979-01-10 21:20 usr/sys/h/systm.h
-rw-rw-r-- 2/2             742 1979-01-10 21:20 usr/sys/h/text.h
```

Adding this detection fixes parsing the archive