### PR TITLE
fix(options): strip relative hardlink linknames

### DIFF
--- a/src/tar/options.ts
+++ b/src/tar/options.ts
@@ -1,5 +1,11 @@
-import { DIRECTORY } from "./constants";
+import { DIRECTORY, LINK } from "./constants";
 import type { TarHeader, UnpackOptions } from "./types";
+
+// Strip the first n components from a path.
+const stripPath = (p: string, n: number): string => {
+	const parts = p.split("/").filter(Boolean);
+	return n >= parts.length ? "" : parts.slice(n).join("/");
+};
 
 // Apply strip, filter, and map options to a header.
 export function transformHeader(
@@ -14,22 +20,22 @@ export function transformHeader(
 
 	// Strip path components.
 	if (strip && strip > 0) {
-		const components = h.name.split("/").filter(Boolean); // Filter empty strings.
+		const newName = stripPath(h.name, strip);
+		if (!newName) return null; // Path is fully stripped
 
-		if (strip >= components.length) return null; // Path is fully stripped
-
-		// Rebuild name after stripping.
-		const newName = components.slice(strip).join("/");
 		h.name =
 			h.type === DIRECTORY && !newName.endsWith("/") ? `${newName}/` : newName;
 
-		// Also strip absolute linknames.
-		if (h.linkname?.startsWith("/")) {
-			const linkComponents = h.linkname.split("/").filter(Boolean);
-			h.linkname =
-				strip >= linkComponents.length
-					? "/" // Fully stripped, but retain root for absolute link.
-					: `/${linkComponents.slice(strip).join("/")}`;
+		// Strip linknames that are archive-root-relative.
+		//
+		// - Hardlink linknames are relative to the archive root, so they must be stripped.
+		// - Symlink linknames are relative to the entry's parent directory, so only absolute symlinks need stripping.
+		if (h.linkname) {
+			const isAbsolute = h.linkname.startsWith("/");
+			if (isAbsolute || h.type === LINK) {
+				const stripped = stripPath(h.linkname, strip);
+				h.linkname = isAbsolute ? `/${stripped}` || "/" : stripped;
+			}
 		}
 	}
 

--- a/tests/fs/options.test.ts
+++ b/tests/fs/options.test.ts
@@ -214,6 +214,29 @@ describe("options fs", () => {
 			expect(files).toContain("test.txt");
 		});
 
+		it.skipIf(process.platform === "win32")(
+			"strips hardlink linknames with strip option",
+			async () => {
+				const binDir = path.join(tmpDir, "source", "wrapper", "bin");
+				await fs.mkdir(binDir, { recursive: true });
+				await fs.writeFile(path.join(binDir, "python3.6"), "python\n");
+				await fs.link(
+					path.join(binDir, "python3.6"),
+					path.join(binDir, "python3.6m"),
+				);
+
+				const extractDir = path.join(tmpDir, "extract");
+				await pipeline(
+					packTar(path.join(tmpDir, "source")),
+					unpackTar(extractDir, { strip: 1 }),
+				);
+
+				const s1 = await fs.stat(path.join(extractDir, "bin", "python3.6"));
+				const s2 = await fs.stat(path.join(extractDir, "bin", "python3.6m"));
+				expect(s1.ino).toBe(s2.ino);
+			},
+		);
+
 		it("inherits core filter option", async () => {
 			const sourceDir = path.join(tmpDir, "source");
 			await fs.mkdir(sourceDir);

--- a/tests/web/options.test.ts
+++ b/tests/web/options.test.ts
@@ -158,32 +158,26 @@ describe("unpack options", () => {
 				expect(symlinkEntry?.header.linkname).toBe("/subdir/target.txt"); // stripped
 			});
 
-			it("preserves relative hardlinks unchanged", async () => {
+			it("strips relative hardlink linknames", async () => {
 				const archive = await packTar([
+					{
+						header: { name: "parent/subdir/target.txt", size: 4, type: "file" },
+						body: "test",
+					},
 					{
 						header: {
 							name: "parent/subdir/mylink",
 							size: 0,
 							type: "link",
-							linkname: "target.txt", // relative hardlink
+							linkname: "parent/subdir/target.txt",
 						},
-					},
-					{
-						header: {
-							name: "parent/subdir/target.txt",
-							size: 4,
-							type: "file",
-						},
-						body: "test",
 					},
 				]);
 
 				const entries = await unpackTar(archive, { strip: 1 });
-
-				expect(entries).toHaveLength(2);
-				const hardlinkEntry = entries.find((e) => e.header.type === "link");
-				expect(hardlinkEntry?.header.name).toBe("subdir/mylink");
-				expect(hardlinkEntry?.header.linkname).toBe("target.txt"); // unchanged
+				const link = entries.find((e) => e.header.type === "link");
+				expect(link?.header.name).toBe("subdir/mylink");
+				expect(link?.header.linkname).toBe("subdir/target.txt");
 			});
 
 			it("strips absolute hardlinks correctly", async () => {


### PR DESCRIPTION
Previously made the assumption that relative hardlink linknames should not be stripped. That is not the case in practice so this strips them if the `strip` option is passed.