### PR TITLE
fix(pax): Fix filename length checking logic

### DIFF
--- a/src/tar/pax.ts
+++ b/src/tar/pax.ts
@@ -17,8 +17,8 @@ export function generatePax(header: TarHeader): {
 } | null {
 	const paxRecords: Record<string, string> = {};
 
-	// Check max filename length.
-	if (header.name.length > USTAR_NAME_SIZE) {
+	// Check max filename length (using byte length for multi-byte safety).
+	if (encoder.encode(header.name).length > USTAR_NAME_SIZE) {
 		const split = findUstarSplit(header.name);
 
 		// If a valid USTAR split is not possible, we must use a PAX record.
@@ -28,16 +28,16 @@ export function generatePax(header: TarHeader): {
 	}
 
 	// Check max linkname length.
-	if (header.linkname && header.linkname.length > USTAR_NAME_SIZE) {
+	if (header.linkname && encoder.encode(header.linkname).length > USTAR_NAME_SIZE) {
 		paxRecords.linkpath = header.linkname;
 	}
 
 	// Check user/group names.
-	if (header.uname && header.uname.length > USTAR_UNAME_SIZE) {
+	if (header.uname && encoder.encode(header.uname).length > USTAR_UNAME_SIZE) {
 		paxRecords.uname = header.uname;
 	}
 
-	if (header.gname && header.gname.length > USTAR_GNAME_SIZE) {
+	if (header.gname && encoder.encode(header.gname).length > USTAR_GNAME_SIZE) {
 		paxRecords.gname = header.gname;
 	}
 
@@ -105,26 +105,28 @@ export function generatePax(header: TarHeader): {
 }
 
 // Tries to split a long path into a USTAR compatible name and prefix.
+// Uses byte lengths to correctly handle multi-byte UTF-8 characters.
 export function findUstarSplit(
 	path: string,
 ): { name: string; prefix: string } | null {
 	// No split needed if the path already fits in the name field.
-	if (path.length <= USTAR_NAME_SIZE) {
+	if (encoder.encode(path).length <= USTAR_NAME_SIZE) {
 		return null;
 	}
 
-	// For the name part to fit, the slash must be at or after this index.
-	const minSlashIndex = path.length - USTAR_NAME_SIZE - 1;
+	// Find the rightmost '/' that allows both parts to fit within byte limits.
+	for (let i = path.length - 1; i > 0; i--) {
+		if (path[i] !== "/") continue;
 
-	// Find the rightmost slash that respects the prefix length limit (155).
-	const slashIndex = path.lastIndexOf("/", USTAR_PREFIX_SIZE);
+		const prefix = path.slice(0, i);
+		const name = path.slice(i + 1);
 
-	// A valid split exists if we found a slash and it allows both parts to fit.
-	if (slashIndex > 0 && slashIndex >= minSlashIndex) {
-		return {
-			prefix: path.slice(0, slashIndex),
-			name: path.slice(slashIndex + 1),
-		};
+		if (
+			encoder.encode(prefix).length <= USTAR_PREFIX_SIZE &&
+			encoder.encode(name).length <= USTAR_NAME_SIZE
+		) {
+			return { prefix, name };
+		}
 	}
 
 	return null; // No valid split point found.

--- a/tests/web/pack-pax.test.ts
+++ b/tests/web/pack-pax.test.ts
@@ -411,6 +411,68 @@ describe("PAX format support", () => {
 			expect(extracted[0].header.pax?.linkpath).toBe(koreanLink);
 		});
 
+		it("uses PAX for multi-byte filenames over 255 bytes", async () => {
+			// 86 Korean chars × 3 bytes = 258 bytes > 255 byte USTAR prefix+name limit.
+			// Cannot be split into prefix(155) + name(100) by bytes.
+			const koreanName = "가".repeat(86);
+
+			const entries: TarEntry[] = [
+				{
+					header: { name: koreanName, size: 4, type: "file" },
+					body: "test",
+				},
+			];
+
+			const buffer = await packTar(entries);
+			const extracted = await unpackTar(buffer);
+
+			expect(extracted).toHaveLength(1);
+			expect(extracted[0].header.name).toBe(koreanName);
+			expect(extracted[0].header.pax?.path).toBe(koreanName);
+			expect(decoder.decode(extracted[0].data)).toBe("test");
+		});
+
+		it("uses PAX for multi-byte path that cannot be USTAR-split by bytes", async () => {
+			// prefix: "가" × 52 = 156 bytes > 155 limit, so no valid split exists.
+			const prefix = "가".repeat(52);
+			const name = `${prefix}/test.txt`;
+
+			const entries: TarEntry[] = [
+				{
+					header: { name, size: 4, type: "file" },
+					body: "test",
+				},
+			];
+
+			const buffer = await packTar(entries);
+			const extracted = await unpackTar(buffer);
+
+			expect(extracted).toHaveLength(1);
+			expect(extracted[0].header.name).toBe(name);
+			expect(extracted[0].header.pax?.path).toBe(name);
+			expect(decoder.decode(extracted[0].data)).toBe("test");
+		});
+
+		it("uses PAX for multi-byte filenames of 30000 chars", async () => {
+			// 300 Korean chars × 3 bytes = 90000 bytes.
+			const koreanName = "가".repeat(30000);
+
+			const entries: TarEntry[] = [
+				{
+					header: { name: koreanName, size: 4, type: "file" },
+					body: "test",
+				},
+			];
+
+			const buffer = await packTar(entries);
+			const extracted = await unpackTar(buffer);
+
+			expect(extracted).toHaveLength(1);
+			expect(extracted[0].header.name).toBe(koreanName);
+			expect(extracted[0].header.pax?.path).toBe(koreanName);
+			expect(decoder.decode(extracted[0].data)).toBe("test");
+		});
+
 		it("handles Unicode characters in filenames with correct PAX record byte lengths", async () => {
 			// Test filenames with multi-byte Unicode characters (emojis)
 			const nameWithEmoji = "long_filename_ending_with_😀";

--- a/tests/web/pack-pax.test.ts
+++ b/tests/web/pack-pax.test.ts
@@ -368,6 +368,49 @@ describe("PAX format support", () => {
 			expect(extracted[1].header.type).toBe("symlink");
 		});
 
+		it("uses PAX for multi-byte filenames under 100 chars but over 100 bytes", async () => {
+			// Korean chars are 3 bytes each in UTF-8.
+			// 34 chars × 3 bytes = 102 bytes > 100 byte USTAR limit, but only 34 chars.
+			const koreanName = "가".repeat(34);
+
+			const entries: TarEntry[] = [
+				{
+					header: { name: koreanName, size: 4, type: "file" },
+					body: "test",
+				},
+			];
+
+			const buffer = await packTar(entries);
+			const extracted = await unpackTar(buffer);
+
+			expect(extracted).toHaveLength(1);
+			expect(extracted[0].header.name).toBe(koreanName);
+			expect(extracted[0].header.pax?.path).toBe(koreanName);
+			expect(decoder.decode(extracted[0].data)).toBe("test");
+		});
+
+		it("uses PAX for multi-byte linkname under 100 chars but over 100 bytes", async () => {
+			const koreanLink = "가".repeat(34);
+
+			const entries: TarEntry[] = [
+				{
+					header: {
+						name: "my-symlink",
+						type: "symlink",
+						linkname: koreanLink,
+						size: 0,
+					},
+				},
+			];
+
+			const buffer = await packTar(entries);
+			const extracted = await unpackTar(buffer);
+
+			expect(extracted).toHaveLength(1);
+			expect(extracted[0].header.linkname).toBe(koreanLink);
+			expect(extracted[0].header.pax?.linkpath).toBe(koreanLink);
+		});
+
 		it("handles Unicode characters in filenames with correct PAX record byte lengths", async () => {
 			// Test filenames with multi-byte Unicode characters (emojis)
 			const nameWithEmoji = "long_filename_ending_with_😀";


### PR DESCRIPTION
The `USTAR_NAME_SIZE`/`USTAR_UNAME_SIZE` length check should be based not on the string’s character length, but on the number of bytes the string occupies.

Without this patch, a serious bug occurs where, if a filename contains non-ASCII characters beyond a certain length, modern-tar arbitrarily truncates the filename during compression.