### PR TITLE
fix(web): respect backpressure in main loop

### DIFF
--- a/src/tar/pax.ts
+++ b/src/tar/pax.ts
@@ -28,7 +28,10 @@ export function generatePax(header: TarHeader): {
 	}
 
 	// Check max linkname length.
-	if (header.linkname && encoder.encode(header.linkname).length > USTAR_NAME_SIZE) {
+	if (
+		header.linkname &&
+		encoder.encode(header.linkname).length > USTAR_NAME_SIZE
+	) {
 		paxRecords.linkpath = header.linkname;
 	}
 

--- a/src/web/unpack.ts
+++ b/src/web/unpack.ts
@@ -44,6 +44,7 @@ export function createTarDecoder(
 	// Pull from the unpacker and push to the appropriate streams.
 	const pump = (
 		controller: TransformStreamDefaultController<ParsedTarEntry>,
+		force = false,
 	) => {
 		if (pumping) return;
 		pumping = true;
@@ -52,13 +53,19 @@ export function createTarDecoder(
 			while (true) {
 				if (unpacker.isEntryActive()) {
 					if (bodyController) {
+						if ((bodyController.desiredSize ?? 1) <= 0) break;
+
 						const fed = unpacker.streamBody(
-							// biome-ignore lint/style/noNonNullAssertion: Checked above.
-							// biome-ignore lint/complexity/noCommaOperator: Smaller callback.
-							(c) => (bodyController!.enqueue(c), true),
+							(c) =>
+								(
+									// biome-ignore lint/style/noNonNullAssertion lint/complexity/noCommaOperator: Checked above and smaller bundle size.
+									bodyController!.enqueue(c),
+									// biome-ignore lint/style/noNonNullAssertion: Checked above.
+									(bodyController!.desiredSize ?? 1) > 0
+								),
 						);
 
-						// Rxeturns 0 if no data is available OR if body is complete.
+						// Returns 0 if no data is available OR if body is complete.
 						if (fed === 0 && !unpacker.isBodyComplete()) break;
 					} else if (!unpacker.skipEntry()) {
 						break;
@@ -74,6 +81,8 @@ export function createTarDecoder(
 						if (!unpacker.skipPadding()) break;
 					}
 				} else {
+					if (!force && (controller.desiredSize ?? 0) < 0) break;
+
 					// If entry is not active, try to read the next header.
 					const header = unpacker.readHeader();
 					if (header === null || header === undefined) break;
@@ -124,7 +133,8 @@ export function createTarDecoder(
 			flush(controller) {
 				try {
 					unpacker.end();
-					pump(controller);
+					// Flush drains any final buffered headers/EOF state after the last write.
+					pump(controller, true);
 					unpacker.validateEOF();
 
 					if (unpacker.isEntryActive() && !unpacker.isBodyComplete()) {

--- a/tests/web/extract.test.ts
+++ b/tests/web/extract.test.ts
@@ -20,6 +20,33 @@ const createBaseArchive = (
 	return packTar(entries);
 };
 
+const readWithTimeout = <T>(
+	promise: Promise<T>,
+	message: string,
+	ms = 100,
+): Promise<T> =>
+	Promise.race([
+		promise,
+		new Promise<never>((_, reject) =>
+			setTimeout(() => reject(new Error(message)), ms),
+		),
+	]);
+
+const expectToStayPending = async <T>(
+	promise: Promise<T>,
+	ms = 50,
+): Promise<void> => {
+	const pending = Symbol("pending");
+	const result = await Promise.race([
+		promise,
+		new Promise<typeof pending>((resolve) =>
+			setTimeout(() => resolve(pending), ms),
+		),
+	]);
+
+	expect(result).toBe(pending);
+};
+
 describe("unpackTar", () => {
 	it("extracts a single file tar", async () => {
 		const buffer = await fs.readFile(ONE_FILE_TAR);
@@ -188,6 +215,148 @@ describe("createTarDecoder", () => {
 		}
 
 		expect(names).toEqual(["dir/", "dir/file.txt", "dir/empty.txt"]);
+	});
+
+	it("pauses body streaming until the current entry is cancelled", async () => {
+		const archive = await createBaseArchive([
+			{
+				header: { name: "large.bin", type: "file", size: 2048 },
+				body: new Uint8Array(2048).fill(97),
+			},
+			{ header: { name: "after.txt", type: "file", size: 5 }, body: "hello" },
+		]);
+
+		const decoder = createTarDecoder();
+		const reader = decoder.readable.getReader();
+		const writer = decoder.writable.getWriter();
+
+		const writeAll = (async () => {
+			for (let i = 0; i < archive.length; i += 128) {
+				await writer.write(archive.subarray(i, i + 128));
+			}
+		})();
+
+		const firstResult = await readWithTimeout(
+			reader.read(),
+			"Timed out waiting for first entry",
+		);
+		expect(firstResult.done).toBe(false);
+		const firstEntry = firstResult.value;
+		if (!firstEntry) throw new Error("Expected first entry");
+		expect(firstEntry.header.name).toBe("large.bin");
+
+		await writeAll;
+
+		const secondReadPromise = reader.read();
+		await expectToStayPending(secondReadPromise);
+
+		await firstEntry.body.cancel();
+
+		const secondResult = await readWithTimeout(
+			secondReadPromise,
+			"Timed out waiting for second entry",
+		);
+		expect(secondResult.done).toBe(false);
+		const secondEntry = secondResult.value;
+		if (!secondEntry) throw new Error("Expected second entry");
+		expect(secondEntry.header.name).toBe("after.txt");
+
+		await secondEntry.body.cancel();
+		await writer.close();
+
+		const finalRead = await readWithTimeout(
+			reader.read(),
+			"Timed out waiting for decoder completion",
+		);
+		expect(finalRead.done).toBe(true);
+	});
+
+	it("limits unread headers while the outer reader stalls", async () => {
+		const archive = await createBaseArchive([
+			{ header: { name: "one/", type: "directory", size: 0 } },
+			{ header: { name: "two/", type: "directory", size: 0 } },
+			{ header: { name: "three/", type: "directory", size: 0 } },
+			{ header: { name: "four/", type: "directory", size: 0 } },
+		]);
+
+		const decoder = createTarDecoder();
+		const reader = decoder.readable.getReader();
+		const writer = decoder.writable.getWriter();
+
+		await writer.write(archive);
+
+		const firstResult = await readWithTimeout(
+			reader.read(),
+			"Timed out waiting for first unread header",
+		);
+		expect(firstResult.done).toBe(false);
+		expect(firstResult.value?.header.name).toBe("one/");
+
+		const secondResult = await readWithTimeout(
+			reader.read(),
+			"Timed out waiting for second unread header",
+		);
+		expect(secondResult.done).toBe(false);
+		expect(secondResult.value?.header.name).toBe("two/");
+
+		const thirdReadPromise = reader.read();
+		await expectToStayPending(thirdReadPromise);
+
+		await writer.close();
+
+		const thirdResult = await readWithTimeout(
+			thirdReadPromise,
+			"Timed out waiting for third unread header",
+		);
+		expect(thirdResult.done).toBe(false);
+		expect(thirdResult.value?.header.name).toBe("three/");
+
+		const fourthResult = await readWithTimeout(
+			reader.read(),
+			"Timed out waiting for fourth unread header",
+		);
+		expect(fourthResult.done).toBe(false);
+		expect(fourthResult.value?.header.name).toBe("four/");
+
+		const finalRead = await readWithTimeout(
+			reader.read(),
+			"Timed out waiting for decoder completion",
+		);
+		expect(finalRead.done).toBe(true);
+	});
+
+	it("flushes trailing buffered entries when the source closes", async () => {
+		const archive = await createBaseArchive([
+			{ header: { name: "one/", type: "directory", size: 0 } },
+			{ header: { name: "two/", type: "directory", size: 0 } },
+			{ header: { name: "three/", type: "directory", size: 0 } },
+		]);
+
+		const decoder = createTarDecoder();
+		const reader = decoder.readable.getReader();
+		const writer = decoder.writable.getWriter();
+
+		await writer.write(archive);
+		await writer.close();
+
+		const names: string[] = [];
+		for (let i = 0; i < 3; i++) {
+			const result = await readWithTimeout(
+				reader.read(),
+				"Timed out waiting for flushed entry",
+			);
+			expect(result.done).toBe(false);
+			if (!result.value) throw new Error("Expected flushed entry");
+			names.push(result.value.header.name);
+		}
+
+		expect(names).toEqual(["one/", "two/", "three/"]);
+
+		const finalRead = await readWithTimeout(
+			reader.read(),
+			"Timed out waiting for decoder completion",
+		);
+		expect(finalRead.done).toBe(true);
 	});
 
 	it("rejects a stream with an invalid checksum in strict mode", async () => {

--- a/tests/web/v7.test.ts
+++ b/tests/web/v7.test.ts
@@ -246,7 +246,9 @@ describe("V7 tar format support", () => {
 			expect(linkEntry.header.size).toBe(0);
 
 			expect(fileEntry.header.name).toBe("next-file.txt");
-			expect(new TextDecoder().decode(fileEntry.data).trim()).toBe("Hello World");
+			expect(new TextDecoder().decode(fileEntry.data).trim()).toBe(
+				"Hello World",
+			);
 		});
 	});
 });


### PR DESCRIPTION
Add a couple body controller desired size checks, which should prevent some edge cases leading to memory exhaustion.