### PR TITLE
fix(unpacker): prevent 32 bit overflow on meta header sizes

### DIFF
--- a/src/tar/unpacker.ts
+++ b/src/tar/unpacker.ts
@@ -120,7 +120,8 @@ export function createUnpacker(options: DecoderOptions = {}) {
 				const metaParser = getMetaParser(internalHeader.type);
 				if (metaParser) {
 					const paddedSize =
-						(internalHeader.size + BLOCK_SIZE_MASK) & ~BLOCK_SIZE_MASK;
+						internalHeader.size +
+						(-internalHeader.size & BLOCK_SIZE_MASK);
 
 					// Check if we have enough data for the meta entry's body using total size.
 					if (available() < BLOCK_SIZE + paddedSize) {

--- a/tests/tar/utils.test.ts
+++ b/tests/tar/utils.test.ts
@@ -9,6 +9,7 @@ import {
 	writeOctal,
 	writeString,
 } from "../../src/tar/encoding";
+import { createTarHeader } from "../../src/tar/header";
 import { createUnpacker } from "../../src/tar/unpacker";
 import { streamToBuffer } from "../../src/web/stream-utils";
 
@@ -451,5 +452,31 @@ describe("tar utilities", () => {
 		}).not.toThrow();
 
 		expect(errorOccurred).toBe(false);
+	});
+
+	it("waits for oversized meta entry bodies without 32-bit overflow", () => {
+		const unpacker = createUnpacker();
+		const hugeMetaSize = 2 ** 31 + 1;
+
+		unpacker.write(
+			createTarHeader({
+				name: "meta",
+				size: hugeMetaSize,
+				type: "pax-header",
+			}),
+		);
+
+		expect(unpacker.readHeader()).toBeNull();
+
+		unpacker.write(
+			createTarHeader({
+				name: "file.txt",
+				size: 0,
+				type: "file",
+			}),
+		);
+
+		// The meta header should remain pending until its declared body arrives.
+		expect(unpacker.readHeader()).toBeNull();
 	});
 });


### PR DESCRIPTION
Prevent a bitwise rounding overflow for block sizes over >2^31, which can accidentally feed the parser the wrong sizes and break the pipeline.