### PR TITLE
fix(fs): use actual filepath on filter over target

### DIFF
--- a/src/fs/pack.ts
+++ b/src/fs/pack.ts
@@ -313,7 +313,7 @@ export function packTar(
 				}
 
 				// BigIntStats have the same methods as regular Stats.
-				if (filter && !filter(target, stat as unknown as Stats)) return;
+				if (filter && !filter(job.source, stat as unknown as Stats)) return;
 
 				// Cast bigint fields to number where safe.
 				let header: TarHeader = {

--- a/tests/fs/options.test.ts
+++ b/tests/fs/options.test.ts
@@ -82,6 +82,32 @@ describe("options fs", () => {
 			expect(files).toEqual(["large.txt"]);
 		});
 
+		it("filters filesystem sources using source paths", async () => {
+			const sensitiveFile = path.join(tmpDir, "secret.txt");
+			await fs.writeFile(sensitiveFile, "top-secret");
+
+			const packStream = packTar(
+				[
+					{
+						type: "file",
+						source: sensitiveFile,
+						target: "safe/secret.txt",
+					},
+				],
+				{
+					filter: (filePath) => !path.isAbsolute(filePath),
+				},
+			);
+
+			const extractDir = path.join(tmpDir, "extract-filter-source");
+			const unpackStream = unpackTar(extractDir);
+			await pipeline(packStream, unpackStream);
+
+			await expect(
+				fs.readFile(path.join(extractDir, "safe", "secret.txt"), "utf-8"),
+			).rejects.toThrow();
+		});
+
 		it("uses map option to transform headers", async () => {
 			const sourceDir = path.join(FIXTURES_DIR, "a");
 			const packStream = packTar(sourceDir, {


### PR DESCRIPTION
When using `filter`, the hook would check the cleaned `target` vs the original filepath (`job.source`), which could be manipulated to bypass it if the attacker uses a harmless looking `target` filename.