### PR TITLE
fix(ustar): add size guard to prevent unnecessary split checks

### DIFF
--- a/src/tar/pax.ts
+++ b/src/tar/pax.ts
@@ -10,6 +10,8 @@ import { decoder, encoder } from "./encoding";
 import { createTarHeader } from "./header";
 import type { TarHeader } from "./types";
 
+const USTAR_SPLIT_MAX_SIZE = USTAR_PREFIX_SIZE + USTAR_NAME_SIZE + 1;
+
 // Checks a tar header for fields that exceed USTAR limits and generates a PAX header entry if necessary.
 export function generatePax(header: TarHeader): {
 	paxHeader: Uint8Array;
@@ -112,10 +114,18 @@ export function generatePax(header: TarHeader): {
 export function findUstarSplit(
 	path: string,
 ): { name: string; prefix: string } | null {
-	// No split needed if the path already fits in the name field.
-	if (encoder.encode(path).length <= USTAR_NAME_SIZE) {
+	const totalPathBytes = encoder.encode(path).length;
+
+	// A USTAR split only applies to UTF-8 paths that overflow name[100] but
+	// still fit within prefix[155] + "/" + name[100].
+	//
+	// Returning null here signals to the caller that a USTAR split is not possible
+	// and a PAX record should be used instead.
+	if (
+		totalPathBytes <= USTAR_NAME_SIZE ||
+		totalPathBytes > USTAR_SPLIT_MAX_SIZE
+	)
 		return null;
-	}
 
 	// Find the rightmost '/' that allows both parts to fit within byte limits.
 	for (let i = path.length - 1; i > 0; i--) {
@@ -127,9 +137,8 @@ export function findUstarSplit(
 		if (
 			encoder.encode(prefix).length <= USTAR_PREFIX_SIZE &&
 			encoder.encode(name).length <= USTAR_NAME_SIZE
-		) {
+		)
 			return { prefix, name };
-		}
 	}
 
 	return null; // No valid split point found.

--- a/tests/web/pack.test.ts
+++ b/tests/web/pack.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { decoder } from "../../src/tar/encoding";
+import { decoder, encoder } from "../../src/tar/encoding";
 import { packTar, type TarEntry, unpackTar } from "../../src/web";
 
 describe("pack", () => {
@@ -192,6 +192,42 @@ describe("pack", () => {
 		// Also do a round-trip to be sure it extracts correctly.
 		const [extracted] = await unpackTar(packedBuffer);
 		expect(extracted.header.name).toBe(longName);
+	});
+
+	it("handles USTAR long filenames with multi-byte characters by byte length", async () => {
+		// 253 UTF-8 bytes: too large for name[100], but still valid for
+		// prefix[155] + "/" + name[100].
+		const expectedPrefix = "가".repeat(51); // 153 UTF-8 bytes
+		const expectedName = "나".repeat(33); // 99 UTF-8 bytes
+		const longName = `${expectedPrefix}/${expectedName}`;
+
+		expect(encoder.encode(longName).length).toBe(253);
+		expect(encoder.encode(expectedPrefix).length).toBeLessThanOrEqual(155);
+		expect(encoder.encode(expectedName).length).toBeLessThanOrEqual(100);
+
+		const entries: TarEntry[] = [
+			{
+				header: { name: longName, size: 4 },
+				body: "test",
+			},
+		];
+
+		const packedBuffer = await packTar(entries);
+		const headerBlock = packedBuffer.slice(0, 512);
+
+		const nameField = decoder.decode(
+			headerBlock.slice(0, 100).filter((b) => b !== 0),
+		);
+		const prefixField = decoder.decode(
+			headerBlock.slice(345, 345 + 155).filter((b) => b !== 0),
+		);
+
+		expect(nameField).toBe(expectedName);
+		expect(prefixField).toBe(expectedPrefix);
+
+		const [extracted] = await unpackTar(packedBuffer);
+		expect(extracted.header.name).toBe(longName);
+		expect(extracted.header.pax?.path).toBeUndefined();
 	});
 
 	it("packs and then extracts successfully (round-trip)", async () => {


### PR DESCRIPTION
Adding a `USTAR_SPLIT_MAX_SIZE` check here prevents a chance of a small DoS attack since the `for` loop to find the rightmost slash could go on forever (especially since the checking function is quadratic). Very minor but valid.