### PR TITLE
fix(fs): remove bounded cache on path conflicts

### DIFF
--- a/src/fs/path-cache.ts
+++ b/src/fs/path-cache.ts
@@ -19,10 +19,11 @@ export const createPathCache = (
 	destDirPath: string,
 	options: UnpackOptionsFS,
 ) => {
+	const { maxDepth = 1024, dmode } = options;
 	// Serializes directory creation operations within the same directory tree.
 	const dirPromises = createCache<Promise<void>>();
 	// Tracks path conflicts to prevent file/directory type mismatches.
-	const pathConflicts = createCache<TarHeader["type"]>();
+	const pathConflicts = new Map<string, TarHeader["type"]>();
 	// Stores hardlinks to be created after all files are written.
 	const deferredLinks: Array<{ linkTarget: string; outPath: string }> = [];
 	// Caches resolved real paths for symlinked directories.
@@ -176,7 +177,6 @@ export const createPathCache = (
 		 */
 		async preparePath(header: TarHeader): Promise<string | undefined> {
 			const { name, linkname, type, mode, mtime } = header;
-			const { maxDepth = 1024, dmode } = options;
 
 			const normalizedName = normalizeHeaderName(name);
 			const destDir = await destDirPromise;

--- a/tests/fs/security.test.ts
+++ b/tests/fs/security.test.ts
@@ -2016,6 +2016,70 @@ describe("security", () => {
 			);
 		});
 
+		it(
+			"preserves duplicate path tracking beyond cache-sized archives",
+			async () => {
+				const extractDir = path.join(tmpDir, "extract");
+				await fs.mkdir(extractDir, { recursive: true });
+
+				const entries: TarEntry[] = [
+					{
+						header: {
+							name: "dup.txt",
+							size: 5,
+							type: "file",
+							mode: 0o644,
+							mtime: new Date(),
+							uid: 0,
+							gid: 0,
+						},
+						body: "FIRST",
+					},
+				];
+
+				for (let i = 0; i < 10000; i++) {
+					entries.push({
+						header: {
+							name: `filler-${i}.txt`,
+							size: 0,
+							type: "file",
+							mode: 0o644,
+							mtime: new Date(),
+							uid: 0,
+							gid: 0,
+						},
+						body: "",
+					});
+				}
+
+				entries.push({
+					header: {
+						name: "dup.txt",
+						size: 6,
+						type: "file",
+						mode: 0o644,
+						mtime: new Date(),
+						uid: 0,
+						gid: 0,
+					},
+					body: "SECOND",
+				});
+
+				const tarBuffer = await packTar(entries);
+				const tarStream = Readable.from([tarBuffer]);
+				const unpackStream = unpackTar(extractDir);
+
+				await expect(pipeline(tarStream, unpackStream)).resolves.toBeUndefined();
+
+				const dupContent = await fs.readFile(
+					path.join(extractDir, "dup.txt"),
+					"utf8",
+				);
+				expect(dupContent).toBe("FIRST");
+			},
+			20_000,
+		);
+
 		it("allows legitimate same-type operations on same path", async () => {
 			const extractDir = path.join(tmpDir, "extract");
 			await fs.mkdir(extractDir, { recursive: true });


### PR DESCRIPTION
`createCache` creates a bounded map that prevents incoming archives from forever populating our maps eventually leading to an OOM condition.

However, `pathConflicts` is necessary to keep unbounded as it is used for secure validation of paths. Keeping it bounded means after we hit 10k records, there may be an opportunity to take advantage of a mismatch.