### PR TITLE
perf(unpacker): reduce allocations and eliminate unnecessary work

### DIFF
--- a/src/tar/checksum.ts
+++ b/src/tar/checksum.ts
@@ -9,19 +9,13 @@ const ASCII_ZERO = 48; // '0'
 // Validates the checksum of a tar header block.
 export function validateChecksum(block: Uint8Array): boolean {
 	const stored = readOctal(block, USTAR_CHECKSUM_OFFSET, USTAR_CHECKSUM_SIZE);
+	const checksumEnd = USTAR_CHECKSUM_OFFSET + USTAR_CHECKSUM_SIZE;
 
-	let sum = 0;
-	for (let i = 0; i < block.length; i++) {
-		// If the byte is part of the checksum field, treat it as a space.
-		if (
-			i >= USTAR_CHECKSUM_OFFSET &&
-			i < USTAR_CHECKSUM_OFFSET + USTAR_CHECKSUM_SIZE
-		) {
-			sum += CHECKSUM_SPACE;
-		} else {
-			sum += block[i];
-		}
-	}
+	// Pre-added with spaces for the checksum field
+	let sum = CHECKSUM_SPACE * USTAR_CHECKSUM_SIZE;
+
+	for (let i = 0; i < USTAR_CHECKSUM_OFFSET; ++i) sum += block[i];
+	for (let i = checksumEnd; i < block.length; ++i) sum += block[i];
 
 	return stored === sum;
 }
@@ -43,7 +37,7 @@ export function writeChecksum(block: Uint8Array): void {
 
 	// Write checksum as a 6-digit octal string directly into the block.
 	// We work backwards from the last digit's position.
-	for (let i = USTAR_CHECKSUM_OFFSET + 6 - 1; i >= USTAR_CHECKSUM_OFFSET; i--) {
+	for (let i = USTAR_CHECKSUM_OFFSET + 6 - 1; i >= USTAR_CHECKSUM_OFFSET; --i) {
 		block[i] = (checksum & 7) + ASCII_ZERO; // (checksum % 8)
 		checksum >>= 3; // Math.floor(checksum / 8)
 	}

--- a/src/tar/checksum.ts
+++ b/src/tar/checksum.ts
@@ -9,13 +9,18 @@ const ASCII_ZERO = 48; // '0'
 // Validates the checksum of a tar header block.
 export function validateChecksum(block: Uint8Array): boolean {
 	const stored = readOctal(block, USTAR_CHECKSUM_OFFSET, USTAR_CHECKSUM_SIZE);
-	const checksumEnd = USTAR_CHECKSUM_OFFSET + USTAR_CHECKSUM_SIZE;
 
-	// Pre-added with spaces for the checksum field
-	let sum = CHECKSUM_SPACE * USTAR_CHECKSUM_SIZE;
-
-	for (let i = 0; i < USTAR_CHECKSUM_OFFSET; ++i) sum += block[i];
-	for (let i = checksumEnd; i < block.length; ++i) sum += block[i];
+	let sum = 0;
+	for (let i = 0; i < block.length; ++i) {
+		if (
+			i >= USTAR_CHECKSUM_OFFSET &&
+			i < USTAR_CHECKSUM_OFFSET + USTAR_CHECKSUM_SIZE
+		) {
+			sum += CHECKSUM_SPACE;
+		} else {
+			sum += block[i];
+		}
+	}
 
 	return stored === sum;
 }

--- a/src/tar/encoding.ts
+++ b/src/tar/encoding.ts
@@ -14,7 +14,7 @@ export function writeString(
 	}
 }
 
-// Writes a number as a zero-padded octal string.
+// Writes a number as a zero-padded octal string using direct byte writes.
 export function writeOctal(
 	view: Uint8Array,
 	offset: number,
@@ -23,10 +23,14 @@ export function writeOctal(
 ) {
 	if (value === undefined) return;
 
-	// Format to an octal string, pad with leading zeros to size - 1.
 	// The final byte is left as 0 (NUL terminator), assuming a zero-filled view.
-	const octalString = value.toString(8).padStart(size - 1, "0");
-	encoder.encodeInto(octalString, view.subarray(offset, offset + size - 1));
+	// Write octal digits right-to-left, filling remaining positions with '0' (0x30).
+	const end = offset + size - 2; // Last digit position (before NUL)
+
+	for (let i = end, v = value; i >= offset; --i) {
+		view[i] = (v & 7) + 48; // (v % 8) + ASCII '0'
+		v >>>= 3;
+	}
 }
 
 // Reads a NUL-terminated string from the view.
@@ -52,7 +56,7 @@ export function readOctal(
 	let value = 0;
 	const end = offset + size;
 
-	for (let i = offset; i < end; i++) {
+	for (let i = offset; i < end; ++i) {
 		const charCode = view[i];
 		if (charCode === 0) break; // Stop at NUL terminator
 		if (charCode === 32) continue; // Ignore whitespace
@@ -83,7 +87,7 @@ export function readNumeric(
 		result = view[offset] & 0x7f;
 
 		// Process the remaining bytes.
-		for (let i = 1; i < size; i++) {
+		for (let i = 1; i < size; ++i) {
 			result = result * 256 + view[offset + i];
 		}
 

--- a/src/tar/header.ts
+++ b/src/tar/header.ts
@@ -39,6 +39,7 @@ import {
 	ZERO_BLOCK,
 } from "./constants";
 import {
+	decoder,
 	readNumeric,
 	readOctal,
 	readString,
@@ -185,7 +186,6 @@ const PAX_MAPPING: Record<
 
 // Parses PAX record data into an overrides object.
 export function parsePax(buffer: Uint8Array): HeaderOverrides {
-	const decoder = new TextDecoder("utf-8");
 	const overrides: HeaderOverrides = Object.create(null);
 	const pax: Record<string, string> = Object.create(null);
 	let offset = 0;
@@ -282,8 +282,8 @@ export function getHeaderBlocks(header: TarHeader): Uint8Array[] {
 
 	// Calculate padding for the PAX body.
 	const paxPadding = -pax.paxBody.length & BLOCK_SIZE_MASK;
-	const paddingBlocks =
-		paxPadding > 0 ? [ZERO_BLOCK.subarray(0, paxPadding)] : [];
 
-	return [pax.paxHeader, pax.paxBody, ...paddingBlocks, base];
+	return paxPadding > 0
+		? [pax.paxHeader, pax.paxBody, ZERO_BLOCK.subarray(0, paxPadding), base]
+		: [pax.paxHeader, pax.paxBody, base];
 }

--- a/src/tar/header.ts
+++ b/src/tar/header.ts
@@ -282,8 +282,8 @@ export function getHeaderBlocks(header: TarHeader): Uint8Array[] {
 
 	// Calculate padding for the PAX body.
 	const paxPadding = -pax.paxBody.length & BLOCK_SIZE_MASK;
+	const paddingBlocks =
+		paxPadding > 0 ? [ZERO_BLOCK.subarray(0, paxPadding)] : [];
 
-	return paxPadding > 0
-		? [pax.paxHeader, pax.paxBody, ZERO_BLOCK.subarray(0, paxPadding), base]
-		: [pax.paxHeader, pax.paxBody, base];
+	return [pax.paxHeader, pax.paxBody, ...paddingBlocks, base];
 }

--- a/src/tar/packer.ts
+++ b/src/tar/packer.ts
@@ -33,12 +33,11 @@ export function createTarPacker(
 				fail("Invalid tar entry size.");
 
 			try {
-				const resolved = { ...header, size };
-				const headerBlocks = getHeaderBlocks(resolved);
+				const headerBlocks = getHeaderBlocks({ ...header, size });
 
 				for (const block of headerBlocks) onData(block);
 
-				currentHeader = resolved;
+				currentHeader = { ...header, size };
 				bytesWritten = 0;
 			} catch (error) {
 				onError(error as Error);

--- a/src/tar/packer.ts
+++ b/src/tar/packer.ts
@@ -1,5 +1,5 @@
 import { isBodyless } from "./body";
-import { BLOCK_SIZE, BLOCK_SIZE_MASK } from "./constants";
+import { BLOCK_SIZE, BLOCK_SIZE_MASK, ZERO_BLOCK } from "./constants";
 import { getHeaderBlocks } from "./header";
 import type { TarHeader } from "./types";
 
@@ -33,10 +33,12 @@ export function createTarPacker(
 				fail("Invalid tar entry size.");
 
 			try {
-				const headerBlocks = getHeaderBlocks({ ...header, size });
+				const resolved = { ...header, size };
+				const headerBlocks = getHeaderBlocks(resolved);
+
 				for (const block of headerBlocks) onData(block);
 
-				currentHeader = { ...header, size };
+				currentHeader = resolved;
 				bytesWritten = 0;
 			} catch (error) {
 				onError(error as Error);
@@ -76,8 +78,8 @@ export function createTarPacker(
 				// Add padding to reach 512-byte boundary.
 				// biome-ignore lint/style/noNonNullAssertion: Checked above.
 				const paddingSize = -currentHeader!.size & BLOCK_SIZE_MASK;
-				// Write padding buffer if needed.
-				if (paddingSize > 0) onData(new Uint8Array(paddingSize));
+				// Write padding buffer if needed, reusing the pre-allocated ZERO_BLOCK.
+				if (paddingSize > 0) onData(ZERO_BLOCK.subarray(0, paddingSize));
 
 				// Reset state.
 				currentHeader = null;

--- a/src/tar/pax.ts
+++ b/src/tar/pax.ts
@@ -20,9 +20,7 @@ export function generatePax(header: TarHeader): {
 	const paxRecords: Record<string, string> = {};
 
 	// Check max filename length (using byte length for multi-byte safety).
-	const nameBytes = encoder.encode(header.name);
-
-	if (nameBytes.length > USTAR_NAME_SIZE) {
+	if (encoder.encode(header.name).length > USTAR_NAME_SIZE) {
 		const split = findUstarSplit(header.name);
 
 		// If a valid USTAR split is not possible, we must use a PAX record.

--- a/src/tar/pax.ts
+++ b/src/tar/pax.ts
@@ -20,7 +20,9 @@ export function generatePax(header: TarHeader): {
 	const paxRecords: Record<string, string> = {};
 
 	// Check max filename length (using byte length for multi-byte safety).
-	if (encoder.encode(header.name).length > USTAR_NAME_SIZE) {
+	const nameBytes = encoder.encode(header.name);
+
+	if (nameBytes.length > USTAR_NAME_SIZE) {
 		const split = findUstarSplit(header.name);
 
 		// If a valid USTAR split is not possible, we must use a PAX record.
@@ -128,7 +130,7 @@ export function findUstarSplit(
 		return null;
 
 	// Find the rightmost '/' that allows both parts to fit within byte limits.
-	for (let i = path.length - 1; i > 0; i--) {
+	for (let i = path.length - 1; i > 0; --i) {
 		if (path[i] !== "/") continue;
 
 		const prefix = path.slice(0, i);

--- a/src/tar/unpacker.ts
+++ b/src/tar/unpacker.ts
@@ -259,17 +259,18 @@ function isZeroBlock(block: Uint8Array): boolean {
 			block.length / 8,
 		);
 
-		for (let i = 0; i < view.length; i++) {
+		for (let i = 0; i < view.length; ++i) {
 			if (view[i] !== 0n) return false;
 		}
 
 		return true;
 	}
 
-	// If the block is not 8-byte aligned, creating a BigUint64Array would throw, so fallback
-	// to counting every byte.
-	for (let i = 0; i < block.length; i++) {
-		if (block[i] !== 0) return false;
+	// If the block is not 8-byte aligned, use DataView for 4-byte checks
+	// (128 iterations instead of 512) without alignment requirements.
+	const dv = new DataView(block.buffer, block.byteOffset, block.length);
+	for (let i = 0; i < block.length; i += 4) {
+		if (dv.getUint32(i) !== 0) return false;
 	}
 
 	return true;

--- a/src/tar/unpacker.ts
+++ b/src/tar/unpacker.ts
@@ -266,11 +266,8 @@ function isZeroBlock(block: Uint8Array): boolean {
 		return true;
 	}
 
-	// If the block is not 8-byte aligned, use DataView for 4-byte checks
-	// (128 iterations instead of 512) without alignment requirements.
-	const dv = new DataView(block.buffer, block.byteOffset, block.length);
-	for (let i = 0; i < block.length; i += 4) {
-		if (dv.getUint32(i) !== 0) return false;
+	for (let i = 0; i < block.length; ++i) {
+		if (block[i] !== 0) return false;
 	}
 
 	return true;

--- a/src/web/unpack.ts
+++ b/src/web/unpack.ts
@@ -35,7 +35,7 @@ import type { ParsedTarEntry } from "./types";
  */
 export function createTarDecoder(
 	options: DecoderOptions = {},
-): TransformStream<Uint8Array, ParsedTarEntry> {
+): ReadableWritablePair<ParsedTarEntry, Uint8Array> {
 	const unpacker = createUnpacker(options);
 	const strict = options.strict ?? false;
 


### PR DESCRIPTION
This PR is just meant to just give it a little extra pep. It aims to improve runtime performance by reducing allocations and eliminating unnecessary work.

~~In `checksum.ts`, `validateChecksum` gets split into 3 loops to avoid a conditional branch on every byte. Basically, it adds some bytes beforehand and afterward so it doesn’t have to think as much in the middle.~~

In `encoding.ts`, `toString(8).padStart()` gets replaced with direct bitwise byte writes, avoiding two string allocations per call.

In `header.ts`, the `decoder` from `encoding` is re-used every time instead of creating a new one per call. ~~Also, `getHeaderBlocks` moves a conditional just a bit earlier to avoid spreading a potentially-empty array.~~

~~In `packer.ts`, `createTarPacker` spreads once into `resolved` instead of twice for `getHeaderBlocks()` and `currentHeader`. I know it’s only one less allocation per entry, so I hope you also find the readability a bit nicer.~~ There’s also a nit change to re-use `ZERO_BLOCK` for some free pre-allocation.

~~In `pax.ts`, `generatePax` caches the encoded header name to avoid some redundant `encoder.encode()` calls. I mean, don’t we all?~~

~~In `unpacker.ts`, `isZeroBlock` gets to use `DataView` with 4-byte reads instead of byte-by-byte reads on unaligned blocks, but I made it sound a lot cooler in the code comment. In fact, this change might be so insignificantly better that I’ve named the entire PR after it.~~

Thanks for making this package. That was really kind of you. Kindness is awesome. Performance is cool, but it isn’t everything. ... which is why, in `unpack.ts`, the return type is fixed, but only because this really nice contributor named @ayuhito was kind of enough to point it out in #129.